### PR TITLE
repositories: fix {,E}{D,ROOT} usage in EAPI 7.

### DIFF
--- a/paludis/repositories/e/ebuild/install_functions.bash
+++ b/paludis/repositories/e/ebuild/install_functions.bash
@@ -37,7 +37,7 @@ into()
         export DESTTREE=
     else
         export DESTTREE="${1}"
-        [[ -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}" ]] || install -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}"
+        [[ -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}" ]] || install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}"
     fi
 }
 
@@ -47,7 +47,7 @@ insinto()
         export INSDESTTREE=
     else
         export INSDESTTREE="${1}"
-        [[ -d "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}" ]] || install -d "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}"
+        [[ -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${INSDESTTREE#/}" ]] || install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${INSDESTTREE#/}"
     fi
 }
 
@@ -57,7 +57,7 @@ exeinto()
         export EXEDESTTREE=
     else
         export EXEDESTTREE="${1}"
-        [[ -d "${!PALUDIS_IMAGE_DIR_VAR}${EXEDESTTREE}" ]] || install -d "${!PALUDIS_IMAGE_DIR_VAR}${EXEDESTTREE}"
+        [[ -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${EXEDESTTREE#/}" ]] || install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${EXEDESTTREE#/}"
     fi
 }
 
@@ -67,8 +67,8 @@ docinto()
         export DOCDESTTREE=
     else
         export DOCDESTTREE="${1}"
-        [[ -d "${!PALUDIS_IMAGE_DIR_VAR}usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE}" ]] || \
-            install -d "${!PALUDIS_IMAGE_DIR_VAR}usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE}"
+        [[ -d "${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE#/}" ]] || \
+            install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE#/}"
     fi
 }
 

--- a/paludis/repositories/e/ebuild/utils/dobin
+++ b/paludis/repositories/e/ebuild/utils/dobin
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting" >&2
 fi
 
@@ -31,16 +31,16 @@ if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed" >&2
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/bin" ]]; then
-    install -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/bin" || paludis_die_or_error "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/bin is not a dir"
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/bin" ]]; then
+    install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/bin" || paludis_die_or_error "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/bin is not a dir"
 fi
 
 ret=0
 for x in "$@" ; do
     if [[ -n ${PALUDIS_NO_CHOWN} ]]; then
-        install -m0755 "${x}" "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/bin" || ret=2
+        install -m0755 "${x}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/bin" || ret=2
     else
-        install -m0755 -o root -g 0 "${x}" "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/bin" || ret=2
+        install -m0755 -o root -g 0 "${x}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/bin" || ret=2
     fi
 done
 

--- a/paludis/repositories/e/ebuild/utils/dodir
+++ b/paludis/repositories/e/ebuild/utils/dodir
@@ -23,13 +23,13 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
 ret=0
 for x in "$@"; do
-    install -d ${DIROPTIONS} "${!PALUDIS_IMAGE_DIR_VAR}${x}" || ret=2
+    install -d ${DIROPTIONS} "${!PALUDIS_IMAGE_DIR_VAR%/}/${x#/}" || ret=2
 done
 
 [[ 0 != "${ret}" ]] && paludis_die_or_error "dodir returned error ${ret}"

--- a/paludis/repositories/e/ebuild/utils/dodoc
+++ b/paludis/repositories/e/ebuild/utils/dodoc
@@ -24,7 +24,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -41,7 +41,7 @@ if [[ $# -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-dir="${!PALUDIS_IMAGE_DIR_VAR}usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE}"
+dir="${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE}"
 if [[ ! -d "${dir}" ]]; then
     install -d "${dir}" || paludis_die_or_error "could not create ${dir}"
 fi

--- a/paludis/repositories/e/ebuild/utils/doexe
+++ b/paludis/repositories/e/ebuild/utils/doexe
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -35,9 +35,9 @@ if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${EXEDESTTREE}" ]]; then
-    if ! install -d "${!PALUDIS_IMAGE_DIR_VAR}${EXEDESTTREE}" ; then
-        paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR}${EXEDESTTREE}"
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${EXEDESTTREE#/}" ]]; then
+    if ! install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${EXEDESTTREE#/}" ; then
+        paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR%/}/${EXEDESTTREE#/}"
     fi
 fi
 
@@ -53,7 +53,7 @@ for x in "$@"; do
     else
         mysrc="${x}"
     fi
-    install ${EXEOPTIONS} "${mysrc}" "${!PALUDIS_IMAGE_DIR_VAR}${EXEDESTTREE}" || ret=2
+    install ${EXEOPTIONS} "${mysrc}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${EXEDESTTREE#/}" || ret=2
 done
 
 [[ 0 != "${ret}" ]] && paludis_die_or_error "doexe returned error ${ret}"

--- a/paludis/repositories/e/ebuild/utils/dohard
+++ b/paludis/repositories/e/ebuild/utils/dohard
@@ -21,7 +21,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     echo "${0}: \${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting" >&2
     exit 247
 fi
@@ -31,4 +31,4 @@ if [[ ${#} -ne 2 ]]; then
     exit 1
 fi
 
-ln -f "${!PALUDIS_IMAGE_DIR_VAR}${1}" "${!PALUDIS_IMAGE_DIR_VAR}${2}"
+ln -f "${!PALUDIS_IMAGE_DIR_VAR%/}/${1#/}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}"

--- a/paludis/repositories/e/ebuild/utils/dohtml
+++ b/paludis/repositories/e/ebuild/utils/dohtml
@@ -23,7 +23,7 @@
 
 source ${PALUDIS_EBUILD_DIR}/0/list_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     echo "${0}: \${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting" >&2
     exit 247
 fi
@@ -95,7 +95,7 @@ install_file() {
 
     [[ -z ${DOCDESTTREE} ]] && DOCDESTTREE="html"
 
-    dir="${!PALUDIS_IMAGE_DIR_VAR}usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE}/${doc_prefix}/${prefix}"
+    dir="${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/doc/${!PALUDIS_NAME_VERSION_REVISION_VAR}/${DOCDESTTREE#/}/${doc_prefix}/${prefix}"
 
     if [[ -f ${path} ]]; then
         ext="$(basename ${path})"

--- a/paludis/repositories/e/ebuild/utils/doinfo
+++ b/paludis/repositories/e/ebuild/utils/doinfo
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -31,15 +31,15 @@ if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}usr/share/info" ]]; then
-    install -d "${!PALUDIS_IMAGE_DIR_VAR}usr/share/info" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR}usr/share/info"
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/info" ]]; then
+    install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/info" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/info"
 fi
 
 ret=0
 
 for x in "$@"; do
     if [[ -e "${x}" ]]; then
-        install -m0644 "${x}" "${!PALUDIS_IMAGE_DIR_VAR}usr/share/info" || ret=2
+        install -m0644 "${x}" "${!PALUDIS_IMAGE_DIR_VAR%/}/usr/share/info" || ret=2
     else
         echo "${0}: ${x} does not exist"
         ret=2

--- a/paludis/repositories/e/ebuild/utils/doins
+++ b/paludis/repositories/e/ebuild/utils/doins
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -54,7 +54,7 @@ if [[ ${INSDESTTREE} == ${!PALUDIS_IMAGE_DIR_VAR}* ]]; then
     paludis_die_or_error
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}" ]]; then
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${INSDESTTREE#/}" ]]; then
     dodir "${INSDESTTREE}"
 fi
 
@@ -63,7 +63,7 @@ ret=0
 for x in "$@"; do
     if [[ -L ${x} ]]; then
         if [[ -n ${PALUDIS_DOINS_SYMLINK} ]] ; then
-            ln -s "$(readlink ${x} )" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}/$(basename "${x}")" || ret=2
+            ln -s "$(readlink ${x} )" "${!PALUDIS_IMAGE_DIR_VAR%/}/${INSDESTTREE#/}/$(basename "${x}")" || ret=2
             continue
         else
             cp "${x}" "${!PALUDIS_TEMP_DIR_VAR}"
@@ -74,7 +74,7 @@ for x in "$@"; do
             continue
         fi
 
-        mydir="${INSDESTTREE}/$(basename "${x}")"
+        mydir="${INSDESTTREE#/}/$(basename "${x}")"
         find "${x}" -mindepth 1 -maxdepth 1 -exec \
             env \
                 INSDESTTREE="${mydir}" \
@@ -85,7 +85,7 @@ for x in "$@"; do
         mysrc="${x}"
     fi
 
-    install ${INSOPTIONS} "${mysrc}" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}" || ret=2
+    install ${INSOPTIONS} "${mysrc}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${INSDESTTREE#/}" || ret=2
 done
 
 [[ 0 != "${ret}" ]] && paludis_die_or_error "doins returned error ${ret}"

--- a/paludis/repositories/e/ebuild/utils/dolib
+++ b/paludis/repositories/e/ebuild/utils/dolib
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -33,7 +33,7 @@ fi
 
 source "${PALUDIS_EBUILD_MODULES_DIR}/multilib_functions.bash"
 
-libdir="${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/$(ebuild_get_libdir)"
+libdir="${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/$(ebuild_get_libdir)"
 
 if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"

--- a/paludis/repositories/e/ebuild/utils/doman
+++ b/paludis/repositories/e/ebuild/utils/doman
@@ -24,7 +24,7 @@
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 source "${PALUDIS_EBUILD_DIR}"/0/list_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -68,11 +68,11 @@ for x in "$@"; do
 
     if [[ ${mandir} =~ ${match} ]]; then
         if [[ -s ${x} ]]; then
-            if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${BASE}/man/${mandir}" ]]; then
-                install -d "${!PALUDIS_IMAGE_DIR_VAR}${BASE}/man/${mandir}"
+            if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${BASE#/}/man/${mandir}" ]]; then
+                install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${BASE#/}/man/${mandir}"
             fi
 
-            install -m0644 "${x}" "${!PALUDIS_IMAGE_DIR_VAR}${BASE}/man/${mandir}/${name}" || ret=2
+            install -m0644 "${x}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${BASE#/}/man/${mandir}/${name}" || ret=2
         elif [[ ! -e ${x} ]]; then
             echo "${0}: ${x} does not exist" >&2
             ret=2

--- a/paludis/repositories/e/ebuild/utils/domo
+++ b/paludis/repositories/e/ebuild/utils/domo
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -31,8 +31,8 @@ if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/share/locale" ]]; then
-    install -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/share/locale" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/share/locale"
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale" ]]; then
+    install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale"
 fi
 
 ret=0
@@ -40,7 +40,7 @@ ret=0
 for x in "$@"; do
     if [[ -e ${x} ]]; then
         mytiny="$(basename "${x}")"
-        mydir="${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/share/locale/${mytiny%.*}/LC_MESSAGES"
+        mydir="${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale/${mytiny%.*}/LC_MESSAGES"
         if [[ ! -d ${mydir} ]]; then
             install -d "${mydir}"
         fi

--- a/paludis/repositories/e/ebuild/utils/dosbin
+++ b/paludis/repositories/e/ebuild/utils/dosbin
@@ -23,7 +23,7 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -31,16 +31,16 @@ if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/sbin" ]]; then
-    install -d "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/sbin" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/sbin"
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/sbin" ]]; then
+    install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/sbin" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/sbin"
 fi
 
 ret=0
 for x in "$@"; do
     if [[ -n ${PALUDIS_NO_CHOWN} ]]; then
-        install -m0755 "${x}" "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/sbin" || ret=2
+        install -m0755 "${x}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/sbin" || ret=2
     else
-        install -m0755 -o root -g 0 "${x}" "${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/sbin" || ret=2
+        install -m0755 -o root -g 0 "${x}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/sbin" || ret=2
     fi
 done
 

--- a/paludis/repositories/e/ebuild/utils/dosed
+++ b/paludis/repositories/e/ebuild/utils/dosed
@@ -21,7 +21,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/} ]]; then
     echo "${0}: \${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting" >&2
     exit 247
 fi
@@ -31,12 +31,12 @@ if [[ ${#} -lt 1 ]]; then
     exit 1
 fi
 
-mysed="s:${!PALUDIS_IMAGE_DIR_VAR}::g"
+mysed="s:${!PALUDIS_IMAGE_DIR_VAR%/}/::g"
 
 ret=0
 
 for x in "$@"; do
-    y="${!PALUDIS_IMAGE_DIR_VAR}${x}"
+    y="${!PALUDIS_IMAGE_DIR_VAR%/}/${x#/}"
     if [[ -e ${y} ]]; then
         if [[ -f "${y}" ]]; then
             sed -i -e "${mysed}" "${y}" || ret=2

--- a/paludis/repositories/e/ebuild/utils/dosym
+++ b/paludis/repositories/e/ebuild/utils/dosym
@@ -25,7 +25,7 @@ source ${PALUDIS_EBUILD_DIR}/die_functions.bash
 source ${PALUDIS_EBUILD_DIR}/pipe_functions.bash
 source ${PALUDIS_EBUILD_DIR}/output_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
@@ -33,13 +33,13 @@ if [[ ${#} -ne 2 ]]; then
     paludis_die_or_error "exactly two arguments needed."
 fi
 
-if [[ ! -d $(dirname "${!PALUDIS_IMAGE_DIR_VAR}$2") ]]; then
+if [[ ! -d $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}") ]]; then
     if [[ -n "${PALUDIS_DOSYM_NO_MKDIR}" ]] ; then
-        die "error: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR}$2" ) does not exist"
+        die "error: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}" ) does not exist"
     else
-        ebuild_notice "qa" "$0: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR}$2") does not exist; creating. Please fix the ebuild to create it explicitly."
+        ebuild_notice "qa" "$0: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}") does not exist; creating. Please fix the ebuild to create it explicitly."
         dodir $(dirname $2)
     fi
 fi
 
-ln -snf "${1}" "${!PALUDIS_IMAGE_DIR_VAR}${2}" || paludis_die_or_error "creation of symlink ${!PALUDIS_IMAGE_DIR_VAR}${2} failed"
+ln -snf "${1}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}" || paludis_die_or_error "creation of symlink ${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/} failed"

--- a/paludis/repositories/e/ebuild/utils/fowners
+++ b/paludis/repositories/e/ebuild/utils/fowners
@@ -23,4 +23,4 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-chown "${@/#\//${!PALUDIS_IMAGE_DIR_VAR}/}" || paludis_die_or_error "chown returned error $?"
+chown "${@/#\//${!PALUDIS_IMAGE_DIR_VAR%/}\/}" || paludis_die_or_error "chown returned error $?"

--- a/paludis/repositories/e/ebuild/utils/fperms
+++ b/paludis/repositories/e/ebuild/utils/fperms
@@ -23,4 +23,4 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-chmod "${@/#\//${!PALUDIS_IMAGE_DIR_VAR}/}" || paludis_die_or_error "chmod returned error $?"
+chmod "${@/#\//${!PALUDIS_IMAGE_DIR_VAR%/}\/}" || paludis_die_or_error "chmod returned error $?"

--- a/paludis/repositories/e/ebuild/utils/keepdir
+++ b/paludis/repositories/e/ebuild/utils/keepdir
@@ -27,5 +27,5 @@ dodir "$@" || exit ${?}
 
 keepfile_name=.keep_${CATEGORY}_${PN}-${SLOT%/*}
 for f in "$@" ; do
-    touch "${!PALUDIS_IMAGE_DIR_VAR}/${f}/${keepfile_name}" || paludis_die_or_error "Couldn't touch ${keepfile_name} in ${f}" || exit 247
+    touch "${!PALUDIS_IMAGE_DIR_VAR%/}/${f#/}/${keepfile_name}" || paludis_die_or_error "Couldn't touch ${keepfile_name} in ${f}" || exit 247
 done


### PR DESCRIPTION
Since the mentioned variables come without a slash appended in EAPI 7,
we now have to make sure that any usage actually contains a slash.

We can hence strip out the last slash from the variables (for previous
EAPIs, not affecting 7) and unconditionally use a slash now.