### PR TITLE
repositories: also accept non-dotted BASH_COMP values.

### DIFF
--- a/paludis/repositories/e/e_repository_TEST_5_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_5_setup.sh
@@ -747,7 +747,7 @@ LICENSE="GPL-2"
 KEYWORDS="test"
 
 pkg_setup() {
-    [[ ${BASH_COMPAT} == 3.2 ]] || die BASH_COMPAT=${BASH_COMPAT}
+    [[ ${BASH_COMPAT} == 3.2 ]] || [[ ${BASH_COMPAT} == 32 ]] || die BASH_COMPAT=${BASH_COMPAT}
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_6_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_6_setup.sh
@@ -2112,7 +2112,7 @@ LICENSE="GPL-2"
 KEYWORDS="test"
 
 pkg_setup() {
-    [[ ${BASH_COMPAT} == 4.4 ]] || die BASH_COMPAT=${BASH_COMPAT}
+    [[ ${BASH_COMPAT} == 4.4 ]] || [[ ${BASH_COMPAT} == 44 ]] || die BASH_COMPAT=${BASH_COMPAT}
 }
 END
 


### PR DESCRIPTION
The BASH_COMP variable accepts both dotted and non-dotted version
numbers.

However, using the (deprecated) shopt values of compatXX will always set
it to a non-dotted value. Setting it to a value automatically enables
the compatXX setting.

Since ebuild.bash now goes ahead to dump all options (via shopt -p),
meddles with them (if necessary) and re-sets them via eval, BASH_COMPAT
will always end up being set to a non-dotted value.

Let's accept both values in the test cases.