### PR TITLE
repositories: match portage stack-up for EXPORT_FUNCTIONS.

### DIFF
--- a/paludis/repositories/e/ebuild/die_functions.bash
+++ b/paludis/repositories/e/ebuild/die_functions.bash
@@ -24,12 +24,12 @@ shopt -s expand_aliases
 
 _paludis_pipestatus=
 alias die='diefunc "${FUNCNAME:-$0}" "$LINENO"'
-alias assert='_paludis_pipestatus="${PIPESTATUS[*]}"; [[ -z "${_paludis_pipestatus//[ 0]/}" ]] || diefunc "${FUNCNAME:-$0}" "$LINENO"'
+alias assert='_paludis_pipestatus=("${PIPESTATUS[@]}"); _paludis_oldIFS="${IFS}"; IFS=$'"'"' \t\n'"'"'; _paludis_pipestatus_expansion="${_paludis_pipestatus[*]}"; [[ -z "${_paludis_pipestatus_expansion//[ 0]/}" ]] && IFS="${_paludis_oldIFS}" || diefunc "${FUNCNAME:-$0}" "$LINENO"'
 # paludis_die_or_error is only for use in scripts
 alias paludis_die_or_error='paludis_die_or_error_func "$0" "$LINENO"'
 # paludis_die_unless_nonfatal and paludis_assert_unless_nonfatal are only for use in shell functions
 alias paludis_die_unless_nonfatal='paludis_die_unless_nonfatal_func "$FUNCNAME" "$LINENO"'
-alias paludis_assert_unless_nonfatal='_paludis_pipestatus="${PIPESTATUS[*]}"; [[ -z "${_paludis_pipestatus//[ 0]/}" ]] || paludis_die_unless_nonfatal_func "$FUNCNAME" "$LINENO"'
+alias paludis_assert_unless_nonfatal='_paludis_pipestatus=("${PIPESTATUS[@]}"); _paludis_oldIFS="${IFS}"; IFS=$'"'"' \t\n'"'"'; _paludis_pipestatus_expansion="${_paludis_pipestatus[*]}"; [[ -z "${_paludis_pipestatus_expansion//[ 0]/}" ]] && IFS="${_paludis_oldIFS}" || paludis_die_unless_nonfatal_func "$FUNCNAME" "$LINENO"'
 
 trap 'echo "die trap: exiting with error." 1>&2 ; exit 250' SIGUSR1
 

--- a/paludis/repositories/e/ebuild/exheres-0/build_functions.bash
+++ b/paludis/repositories/e/ebuild/exheres-0/build_functions.bash
@@ -24,7 +24,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 alias die_unless_nonfatal='paludis_die_unless_nonfatal_func "$FUNCNAME" "$LINENO"'
-alias assert_unless_nonfatal='_pipestatus="${PIPESTATUS[*]}"; [[ -z "${_pipestatus//[ 0]/}" ]] || paludis_die_unless_nonfatal_func "$FUNCNAME" "$LINENO" "$_pipestatus"'
+alias assert_unless_nonfatal='_paludis_pipestatus=("${PIPESTATUS[@]}"); _paludis_oldIFS="${IFS}"; IFS=$'"'"' \t\n'"'"'; _paludis_pipestatus_expansion="${_paludis_pipestatus[*]}"; [[ -z "${_paludis_pipestatus_expansion//[ 0]/}" ]] && IFS="${_paludis_oldIFS}" || paludis_die_unless_nonfatal_func "$FUNCNAME" "$LINENO" "$_paludis_pipestatus_expansion"'
 
 nonfatal()
 {

--- a/paludis/repositories/e/ebuild/utils/unpack
+++ b/paludis/repositories/e/ebuild/utils/unpack
@@ -33,8 +33,12 @@ die()
 
 assert()
 {
-    local _pipestatus="${PIPESTATUS[*]}"
-    [[ -z "${_pipestatus//[ 0]/}" ]] || die "$@: $_pipestatus"
+    local _paludis_pipestatus=("${PIPESTATUS[@]}")
+    local _oldIFS="${IFS}"
+    IFS=$' \t\n'
+    local _paludis_pipestatus_expansion="${_paludis_pipestatus[*]}"
+    [[ -z "${_paludis_pipestatus_expansion//[ 0]/}" ]] || die "$@: $_paludis_pipestatus_expansion"
+    IFS="${_oldIFS}"
 }
 
 unpack_tar() {


### PR DESCRIPTION
Since PMS does not specify in which way `EXPORT_FUNCTIONS` is supposed to
be evaluated in recursive inherit scenarios, the only authoritative place
is portage's code.

Hence, let's emulate the stack-up behavior that was introduced in 2009.

Fixes: #31 

---

Draft. Don't merge until the #33 is merged.