### PR TITLE
Fix recursive doins behavior for paths with whitespace

### DIFF
--- a/paludis/repositories/e/e_repository_TEST_0_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_0_setup.sh
@@ -878,6 +878,16 @@ src_unpack() {
     echo foo > foo
     ln -s foo bar
 
+    cd ..
+
+    mkdir 'c c'
+    cd 'c c'
+    echo tre > tre
+    echo 'ty ui' > 'ty ui'
+    ln -s tre iioo
+    ln -s tre 'oo pp'
+    ln -s 'ty ui' jjkk
+    ln -s 'ty ui' 'kk ll'
 }
 
 src_install() {
@@ -887,6 +897,8 @@ src_install() {
     newins a/adfs asdf
     cd b
     doins -r .
+    cd ..
+    doins -r 'c c'
 }
 
 pkg_preinst() {
@@ -898,6 +910,16 @@ pkg_preinst() {
     [[ -f ${D}/foo/foo ]] || die foo
     [[ -L ${D}/foo/bar ]] || die bar
     [[ $(readlink ${D}/foo/bar ) == foo ]] || die sym
+    [[ -f "${D}/foo/c c/tre" ]] || die tre
+    [[ -L "${D}/foo/c c/iioo" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/iioo" ) == tre ]] || die sym
+    [[ -L "${D}/foo/c c/oo pp" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/oo pp" ) == tre ]] || die sym
+    [[ -f "${D}/foo/c c/ty ui" ]] || die 'ty ui'
+    [[ -L "${D}/foo/c c/jjkk" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/jjkk" ) == 'ty ui' ]] || die sym
+    [[ -L "${D}/foo/c c/kk ll" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/kk ll" ) == 'ty ui' ]] || die sym
 }
 END
 mkdir -p "cat/banned-functions"

--- a/paludis/repositories/e/e_repository_TEST_1_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_1_setup.sh
@@ -816,6 +816,16 @@ src_unpack() {
     echo foo > foo
     ln -s foo bar
 
+    cd ..
+
+    mkdir 'c c'
+    cd 'c c'
+    echo tre > tre
+    echo 'ty ui' > 'ty ui'
+    ln -s tre iioo
+    ln -s tre 'oo pp'
+    ln -s 'ty ui' jjkk
+    ln -s 'ty ui' 'kk ll'
 }
 
 src_install() {
@@ -825,6 +835,8 @@ src_install() {
     newins a/adfs asdf
     cd b
     doins -r .
+    cd ..
+    doins -r 'c c'
 }
 
 pkg_preinst() {
@@ -836,6 +848,16 @@ pkg_preinst() {
     [[ -f ${D}/foo/foo ]] || die foo
     [[ -L ${D}/foo/bar ]] || die bar
     [[ $(readlink ${D}/foo/bar ) == foo ]] || die sym
+    [[ -f "${D}/foo/c c/tre" ]] || die tre
+    [[ -L "${D}/foo/c c/iioo" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/iioo" ) == tre ]] || die sym
+    [[ -L "${D}/foo/c c/oo pp" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/oo pp" ) == tre ]] || die sym
+    [[ -f "${D}/foo/c c/ty ui" ]] || die 'ty ui'
+    [[ -L "${D}/foo/c c/jjkk" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/jjkk" ) == 'ty ui' ]] || die sym
+    [[ -L "${D}/foo/c c/kk ll" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/kk ll" ) == 'ty ui' ]] || die sym
 }
 END
 mkdir -p "cat/banned-functions"

--- a/paludis/repositories/e/e_repository_TEST_2_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_2_setup.sh
@@ -813,6 +813,16 @@ src_unpack() {
     echo foo > foo
     ln -s foo bar
 
+    cd ..
+
+    mkdir 'c c'
+    cd 'c c'
+    echo tre > tre
+    echo 'ty ui' > 'ty ui'
+    ln -s tre iioo
+    ln -s tre 'oo pp'
+    ln -s 'ty ui' jjkk
+    ln -s 'ty ui' 'kk ll'
 }
 
 src_install() {
@@ -822,6 +832,8 @@ src_install() {
     newins a/adfs asdf
     cd b
     doins -r .
+    cd ..
+    doins -r 'c c'
 }
 
 pkg_preinst() {
@@ -833,6 +845,16 @@ pkg_preinst() {
     [[ -f ${D}/foo/foo ]] || die foo
     [[ -L ${D}/foo/bar ]] || die bar
     [[ $(readlink ${D}/foo/bar ) == foo ]] || die sym
+    [[ -f "${D}/foo/c c/tre" ]] || die tre
+    [[ -L "${D}/foo/c c/iioo" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/iioo" ) == tre ]] || die sym
+    [[ -L "${D}/foo/c c/oo pp" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/oo pp" ) == tre ]] || die sym
+    [[ -f "${D}/foo/c c/ty ui" ]] || die 'ty ui'
+    [[ -L "${D}/foo/c c/jjkk" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/jjkk" ) == 'ty ui' ]] || die sym
+    [[ -L "${D}/foo/c c/kk ll" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/kk ll" ) == 'ty ui' ]] || die sym
 }
 END
 mkdir -p "cat/banned-functions"

--- a/paludis/repositories/e/e_repository_TEST_4_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_4_setup.sh
@@ -823,6 +823,16 @@ src_unpack() {
     echo foo > foo
     ln -s foo bar
 
+    cd ..
+
+    mkdir 'c c'
+    cd 'c c'
+    echo tre > tre
+    echo 'ty ui' > 'ty ui'
+    ln -s tre iioo
+    ln -s tre 'oo pp'
+    ln -s 'ty ui' jjkk
+    ln -s 'ty ui' 'kk ll'
 }
 
 src_install() {
@@ -832,6 +842,8 @@ src_install() {
     newins a/adfs asdf
     cd b
     doins -r .
+    cd ..
+    doins -r 'c c'
 }
 
 pkg_preinst() {
@@ -843,6 +855,16 @@ pkg_preinst() {
     [[ -f ${D}/foo/foo ]] || die foo
     [[ -L ${D}/foo/bar ]] || die bar
     [[ $(readlink ${D}/foo/bar ) == foo ]] || die sym
+    [[ -f "${D}/foo/c c/tre" ]] || die tre
+    [[ -L "${D}/foo/c c/iioo" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/iioo" ) == tre ]] || die sym
+    [[ -L "${D}/foo/c c/oo pp" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/oo pp" ) == tre ]] || die sym
+    [[ -f "${D}/foo/c c/ty ui" ]] || die 'ty ui'
+    [[ -L "${D}/foo/c c/jjkk" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/jjkk" ) == 'ty ui' ]] || die sym
+    [[ -L "${D}/foo/c c/kk ll" ]] || die sym
+    [[ $(readlink "${D}/foo/c c/kk ll" ) == 'ty ui' ]] || die sym
 }
 END
 mkdir -p "cat/banned-functions"

--- a/paludis/repositories/e/ebuild/utils/doins
+++ b/paludis/repositories/e/ebuild/utils/doins
@@ -23,27 +23,26 @@
 
 source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
 
-if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR} ]]; then
+if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}" ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
 fi
 
-if [[ ! -d ${!PALUDIS_TEMP_DIR_VAR} ]]; then
+if [[ ! -d "${!PALUDIS_TEMP_DIR_VAR}" ]]; then
     paludis_die_or_error "\${${PALUDIS_TEMP_DIR_VAR}} not valid; aborting"
 fi
 
-if [[ ${#} -lt 1 ]]; then
+if [[ "${#}" -lt '1' ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-if [[ ${1} == "-r" ]]; then
-    DOINSRECUR=y
+DOINSRECUR='n'
+if [[ "${1}" == '-r' ]]; then
+    DOINSRECUR='y'
     shift
-else
-    DOINSRECUR=n
 fi
 
 if [[ -z "${INSDEPTH}" ]]; then
-    declare -i INSDEPTH=0
+    declare -i INSDEPTH='0'
 fi
 
 if [[ ${INSDESTTREE} == ${!PALUDIS_IMAGE_DIR_VAR}* ]]; then
@@ -58,24 +57,24 @@ if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}" ]]; then
     dodir "${INSDESTTREE}"
 fi
 
-ret=0
+ret='0'
 
 for x in "$@"; do
-    if [[ -L ${x} ]]; then
-        if [[ -n ${PALUDIS_DOINS_SYMLINK} ]] ; then
-            ln -s "$(readlink ${x} )" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}/$(basename "${x}")" || ret=2
+    if [[ -L "${x}" ]]; then
+        if [[ -n "${PALUDIS_DOINS_SYMLINK}" ]] ; then
+            ln -s "$(readlink "${x}" )" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}/$(basename "${x}")" || ret='2'
             continue
         else
             cp "${x}" "${!PALUDIS_TEMP_DIR_VAR}"
             mysrc="${!PALUDIS_TEMP_DIR_VAR}/$(basename "${x}")"
         fi
-    elif [[ -d ${x} ]]; then
-        if [[ ${DOINSRECUR} == "n" ]]; then
+    elif [[ -d "${x}" ]]; then
+        if [[ "${DOINSRECUR}" == 'n' ]]; then
             continue
         fi
 
         mydir="${INSDESTTREE}/$(basename "${x}")"
-        find "${x}" -mindepth 1 -maxdepth 1 -exec \
+        find "${x}" -mindepth '1' -maxdepth '1' -exec \
             env \
                 INSDESTTREE="${mydir}" \
                 INSDEPTH=$((INSDEPTH+1)) \
@@ -85,8 +84,8 @@ for x in "$@"; do
         mysrc="${x}"
     fi
 
-    install ${INSOPTIONS} "${mysrc}" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}" || ret=2
+    install ${INSOPTIONS} "${mysrc}" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}" || ret='2'
 done
 
-[[ 0 != "${ret}" ]] && paludis_die_or_error "doins returned error ${ret}"
-exit ${ret}
+[[ '0' != "${ret}" ]] && paludis_die_or_error "doins returned error ${ret}"
+exit "${ret}"


### PR DESCRIPTION
Target paths were not correctly quoted for recursive doins invocations, which lead to breakage.

A simple example would be "bar" -> "fo o", which would not have worked at all.

Fix this by quoting the files we're working with correctly, and add more extensive test cases for paths like these.

While at it, generally try to quote all unsafe components in doins.
    
Fixes: MageSlayer/paludis-gentoo-patches#40

This PR requires #37 to be merged first. Will undraft it as soon as that's the case.