### PR TITLE
ebuild: fix echo_functions include

### DIFF
--- a/doc/configuration/hooks.html.part
+++ b/doc/configuration/hooks.html.part
@@ -403,7 +403,7 @@ hook_run_install_all_post()
 {
     # ensure that einfo etc are available
     export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-    source ${PALUDIS_EBUILD_DIR}/echo_functions.bash
+    source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
     echo
     einfo "Checking for monkeys..."

--- a/doc/configuration/syncers.html.part.in
+++ b/doc/configuration/syncers.html.part.in
@@ -57,7 +57,7 @@ not for end user use.</p>
     exit status.</li>
 </ul>
 
-<p>Many syncers use <code>source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"</code> early on to get access to
+<p>Many syncers use <code>source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"</code> early on to get access to
 <code>ewarn</code> and friends.</p>
 
 <p>For examples, consult the built-in syncers, which can be found in <code>LIBEXECDIR/paludis/syncers/</code>.</p>

--- a/hooks/eselect_env_update.bash.in
+++ b/hooks/eselect_env_update.bash.in
@@ -17,7 +17,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 if [[ -n "${PALUDIS_NO_LIVE_DESTINATION}" ]] ; then
     einfo_unhooked "No need to regenerate environment"

--- a/hooks/find_config_updates.hook
+++ b/hooks/find_config_updates.hook
@@ -25,7 +25,7 @@ check_for_config_updates()
     shopt -s extglob
 
     export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-    source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+    source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
     if [[ -n "${PALUDIS_NO_LIVE_DESTINATION}" ]] ; then
         einfo_unhooked "No need to search for configuration files requiring action"
@@ -64,7 +64,7 @@ check_for_config_updates()
 stale_hook()
 {
     export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-    source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+    source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
     echo
     ewarn "find_config_updates hook should not be run in phase '${HOOK}'"

--- a/hooks/gnu_info_index.bash
+++ b/hooks/gnu_info_index.bash
@@ -17,7 +17,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 if [[ -n "${PALUDIS_NO_LIVE_DESTINATION}" ]] ; then
     einfo_unhooked "No need to update the GNU info directory"

--- a/hooks/installable_cache_regen.bash
+++ b/hooks/installable_cache_regen.bash
@@ -17,7 +17,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 echo
 einfo_unhooked "Regenerating cache for installable repositories..."

--- a/hooks/news.hook.in
+++ b/hooks/news.hook.in
@@ -20,7 +20,7 @@ check_for_news()
 {
     export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
     export ROOT="${ROOT}"
-    source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+    source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
     count="$(@CONFIG_FRAMEWORK@ news count )"
 
     done_echo=
@@ -36,7 +36,7 @@ check_for_news()
 stale_hook()
 {
     export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-    source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+    source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
     echo
     ewarn "news hook should not be run in phase '${HOOK}'"

--- a/hooks/update_config_protect_list.bash
+++ b/hooks/update_config_protect_list.bash
@@ -17,7 +17,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
-source ${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 if [[ -n "${PALUDIS_NO_LIVE_DESTINATION}" ]] ; then
     einfo_unhooked "No need to update CONFIG_PROTECT lists"

--- a/paludis/fetchers/demos/docurl
+++ b/paludis/fetchers/demos/docurl
@@ -8,7 +8,7 @@
 # Set EXTRA_CURL in paludis' bashrc for extra options for curl.
 
 export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-source ${PALUDIS_EBUILD_DIR}/echo_functions.bash
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/fetchers/dowget.in
+++ b/paludis/fetchers/dowget.in
@@ -17,7 +17,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 export PATH="$(${PALUDIS_EBUILD_DIR}/utils/canonicalise ${PALUDIS_EBUILD_DIR}/utils/ ):${PATH}"
-source ${PALUDIS_EBUILD_DIR}/echo_functions.bash
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dobzr.in
+++ b/paludis/syncers/dobzr.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/docvs.in
+++ b/paludis/syncers/docvs.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dodarcs.in
+++ b/paludis/syncers/dodarcs.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dodummy
+++ b/paludis/syncers/dodummy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dogit.in
+++ b/paludis/syncers/dogit.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dohg.in
+++ b/paludis/syncers/dohg.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dorsync.in
+++ b/paludis/syncers/dorsync.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dosvn.in
+++ b/paludis/syncers/dosvn.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a

--- a/paludis/syncers/dotar.in
+++ b/paludis/syncers/dotar.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "${PALUDIS_EBUILD_DIR}/echo_functions.bash"
+source "${PALUDIS_ECHO_FUNCTIONS_DIR:-${PALUDIS_EBUILD_DIR}}/echo_functions.bash"
 
 old_set=$-
 set -a


### PR DESCRIPTION
`echo_functions.bash` is usually available in `PALUDIS_ECHO_FUNCTIONS_DIR`, with a fallback to `PALUDIS_EBUILD_DIR`.

Make sure that all inclusions actually use that, including the documentation.

Patch provided by @negril.