### PR TITLE
action: add reset() to PretendAction and reset the state for each pretend run.

### DIFF
--- a/paludis/action.cc
+++ b/paludis/action.cc
@@ -136,6 +136,12 @@ PretendAction::set_failed()
     _imp->failed = true;
 }
 
+void
+PretendAction::reset()
+{
+    _imp->failed = false;
+}
+
 namespace paludis
 {
     template <>

--- a/paludis/action.hh
+++ b/paludis/action.hh
@@ -443,6 +443,9 @@ namespace paludis
             /// Mark the action as failed.
             void set_failed();
 
+            /// Mark the action as succeeded.
+            void reset();
+
             /**
              * \since 0.36
              */

--- a/paludis/repositories/e/ebuild_id.cc
+++ b/paludis/repositories/e/ebuild_id.cc
@@ -1313,6 +1313,7 @@ namespace
         {
             auto repo(env->fetch_repository(id->repository_name()));
             auto e_repo(std::static_pointer_cast<const ERepository>(repo));
+            action.reset();
             if (! do_pretend_action(
                         env,
                         e_repo.get(),


### PR DESCRIPTION
This one is a bit tricky. I'll explain it more verbosely.

<s>Usually, all states are sticky. This makes sense, since it means we can easily resume operations without having to re-execute steps that were already executed once (think of `cave resume` for instance). Re-execution is slow at best and would break things at worst, like unpacking the source tree again after a successful build.</s>

The original description above was bogus. States aren't usually sticky, as far as I can see, it's just that the `PretendAction` state is only set to `failed` if a pretend operation fails. The state starts out as `non-failed`, but having one pretend operation fail means that the `PretendAction` state can only ever stay on `failed`.

Unfortunately, this also means that we cannot execute pretend actions for the same package multiple times and correctly check the new state. I'd like to do that, though, in our test suite, for testing different USE flag variations/combinations for USE restrictions.

There are multiple ways to have that working:
  - reset the pretend action before each visit (done here), <s>which means that pretend actions effectively aren't cached any longer, so it has a very slight performance impact (but since most pretend actions are empty or very lightweight, that shouldn't really matter)</s> which makes sure that it's re-initialized to `non-false` and shouldn't have bad implications
  - <s>find a way to clean up a package programmatically before re-executing the pretend action (haven't found an easy way of doing this)</s> manually reset the pretend action state before executing the next pretend action
  - create `n` duplicate packages for `n` different pretend runs. That's ugly, because it blows up the test case code a lot, but it would also work.

I've decided to go with the first method, but the third one would also be viable. It didn't make sense to implement it this way, though.

<s>Keeping this PR open for a bit for others to chime in.</s>

This should be rather safe, so merging directly after all.