### PR TITLE
ebuild: work around bash bug related to BASH_COMPAT and shopt compat* options.

### DIFF
--- a/paludis/repositories/e/ebuild/ebuild.bash
+++ b/paludis/repositories/e/ebuild/ebuild.bash
@@ -394,6 +394,7 @@ ebuild_load_ebuild()
         eval paludis_saved_${paludis_v}='${!paludis_v}'
     done
 
+    local old_BASH_COMPAT="${BASH_COMPAT}"
     local paludis_shopts=$(shopt -p)
     [[ -n ${PALUDIS_SHELL_OPTIONS_GLOBAL} ]] && shopt -s ${PALUDIS_SHELL_OPTIONS_GLOBAL}
 
@@ -404,6 +405,22 @@ ebuild_load_ebuild()
     source ${1} || die "Error sourcing ebuild '${1}'"
 
     eval "${paludis_shopts}"
+
+    # Some bash versions have a bug in which even unsetting a previously unset
+    # compat option resets ${BASH_COMPAT} to the default value for the running
+    # bash version, which typically is its current version.
+    # Reset this variable with the saved value if needed.
+    if [[ -n "${old_BASH_COMPAT}" ]]; then
+        # Note that the following comparison might be true even though the
+        # actual value does not differ, since bash likes to drop the dot from
+        # this variable.
+        # It's too complicated to check for that and just resetting the value,
+        # even if it's logically the same, doesn't cause issues, so we'll just
+        # do that.
+        if [[ "${old_BASH_COMPAT}" != "${BASH_COMPAT}" ]]; then
+            BASH_COMPAT="${old_BASH_COMPAT}"
+        fi
+    fi
 
     # we may or may not use this later
     PALUDIS_EBUILD_RDEPEND_WAS_SET=


### PR DESCRIPTION
Some bash versions (notably at least 5.1) reset `BASH_COMPAT` to the default value (for 5.1, that's `51`) if a compat shell option is unset, even if it was previously unset. Normally, such a sequence should be a no-op, but due to the bug, it isn't.

Work around this by saving the `${BASH_COMPAT}` value before the `eval "$(shopt -p)"` call and restore it if `${BASH_COMPAT}` does not match the original value any longer.

Just a safe bugfix, merging right away.