### PR TITLE
ebuild: utils: fix files and install paths with spaces in domo.

### DIFF
--- a/paludis/repositories/e/ebuild/utils/domo
+++ b/paludis/repositories/e/ebuild/utils/domo
@@ -38,10 +38,10 @@ fi
 ret=0
 
 for x in "$@"; do
-    if [[ -e ${x} ]]; then
+    if [[ -e "${x}" ]]; then
         mytiny="$(basename "${x}")"
         mydir="${!PALUDIS_IMAGE_DIR_VAR}${DESTTREE}/share/locale/${mytiny%.*}/LC_MESSAGES"
-        if [[ ! -d ${mydir} ]]; then
+        if [[ ! -d "${mydir}" ]]; then
             install -d "${mydir}"
         fi
         install -m0644 "${x}" "${mydir}/${MOPREFIX}.mo" || ret=2


### PR DESCRIPTION
`domo` didn't handle paths with spaces correctly.

I don't remember what package I have experienced the breakage with, but the fix is easy and actually necessary anyway.

Merging directly.