### PR TITLE
eapis: add help-dependent --with-sysroot econf option.

### DIFF
--- a/paludis/repositories/e/eapis/7.conf
+++ b/paludis/repositories/e/eapis/7.conf
@@ -31,3 +31,5 @@ binary_from_env_variables = ${binary_from_env_variables} BDEPEND
 source_merged_variables = ${source_merged_variables} BDEPEND
 
 load_modules = ${load_modules} version_functions
+
+econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --with-sysroot::--with-sysroot=\${ESYSROOT:-/}


### PR DESCRIPTION
`EAPI=7` defines a new help-dependent `--with-sysroot` default econf option, so we'll just pass that too.