### PR TITLE
Only log to stderr for EAPI=7+

### DIFF
--- a/paludis/repositories/e/e_repository_TEST_0_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_0_setup.sh
@@ -722,13 +722,13 @@ EAPI="0"
 
 src_unpack() {
     local OUT=$(einfon "einfon output.")
-    [ -z "$OUT" ] || die "einfon failed"
+    [ -n "$OUT" ] || die "einfon failed"
 
     OUT=$(einfo "einfo output.")
-    [ -z "$OUT" ] || die "einfo failed"
+    [ -n "$OUT" ] || die "einfo failed"
 
     OUT=$(elog "elog output.")
-    [ -z "$OUT" ] || die "elog failed"
+    [ -n "$OUT" ] || die "elog failed"
 
     OUT=$(ewarn "ewarn output.")
     [ -z "$OUT" ] || die "ewarn failed"

--- a/paludis/repositories/e/eapi.cc
+++ b/paludis/repositories/e/eapi.cc
@@ -258,6 +258,7 @@ namespace
                         n::econf_extra_options() = k.get("econf_extra_options"),
                         n::econf_extra_options_help_dependent() = k.get("econf_extra_options_help_dependent"),
                         n::failure_is_fatal() = destringify_key<bool>(k, "failure_is_fatal"),
+                        n::log_to_stdout() = destringify_key<bool>(k, "log_to_stdout"),
                         n::new_stdin() = destringify_key<bool>(k, "new_stdin"),
                         n::unpack_any_path() = destringify_key<bool>(k, "unpack_any_path"),
                         n::unpack_case_insensitive() = destringify_key<bool>(k, "unpack_case_insensitive"),

--- a/paludis/repositories/e/eapi.hh
+++ b/paludis/repositories/e/eapi.hh
@@ -158,6 +158,7 @@ namespace paludis
         typedef Name<struct name_licence_last_checked> licence_last_checked;
         typedef Name<struct name_license> license;
         typedef Name<struct name_load_modules> load_modules;
+        typedef Name<struct name_log_to_stdout> log_to_stdout;
         typedef Name<struct name_long_description> long_description;
         typedef Name<struct name_merger_options> merger_options;
         typedef Name<struct name_metadata_key> metadata_key;
@@ -503,6 +504,7 @@ namespace paludis
             NamedValue<n::econf_extra_options, std::string> econf_extra_options;
             NamedValue<n::econf_extra_options_help_dependent, std::string> econf_extra_options_help_dependent;
             NamedValue<n::failure_is_fatal, bool> failure_is_fatal;
+            NamedValue<n::log_to_stdout, bool> log_to_stdout;
             NamedValue<n::new_stdin, bool> new_stdin;
             NamedValue<n::unpack_any_path, bool> unpack_any_path;
             NamedValue<n::unpack_case_insensitive, bool> unpack_case_insensitive;

--- a/paludis/repositories/e/eapis/0.conf
+++ b/paludis/repositories/e/eapis/0.conf
@@ -286,6 +286,7 @@ doins_symlink = false
 dosym_mkdir = true
 failure_is_fatal = false
 die_supports_dash_n = false
+log_to_stdout = true
 no_s_workdir_fallback = false
 use_with_enable_empty_third_argument = false
 best_has_version_host_root = false

--- a/paludis/repositories/e/eapis/7.conf
+++ b/paludis/repositories/e/eapis/7.conf
@@ -33,3 +33,5 @@ source_merged_variables = ${source_merged_variables} BDEPEND
 load_modules = ${load_modules} version_functions
 
 econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --with-sysroot::--with-sysroot=\${ESYSROOT:-/}
+
+log_to_stdout = false

--- a/paludis/repositories/e/eapis/exheres-0.conf
+++ b/paludis/repositories/e/eapis/exheres-0.conf
@@ -364,6 +364,7 @@ dosym_mkdir = false
 doins_symlink = true
 failure_is_fatal = true
 die_supports_dash_n = false
+log_to_stdout = true
 no_s_workdir_fallback = true
 use_with_enable_empty_third_argument = true
 fix_mtimes = true

--- a/paludis/repositories/e/eapis/paludis-1.conf
+++ b/paludis/repositories/e/eapis/paludis-1.conf
@@ -283,6 +283,7 @@ doman_lang_filenames_overrides = false
 dodoc_r = false
 dosym_mkdir = false
 doins_symlink = false
+log_to_stdout = true
 use_with_enable_empty_third_argument = true
 failure_is_fatal = false
 die_supports_dash_n = false

--- a/paludis/repositories/e/ebuild.cc
+++ b/paludis/repositories/e/ebuild.cc
@@ -258,6 +258,7 @@ EbuildCommand::operator() ()
         .setenv("PALUDIS_USE_WITH_ENABLE_EMPTY_THIRD_ARGUMENT",
                 tools->use_with_enable_empty_third_argument() ? "yes" : "")
         .setenv("PALUDIS_FAILURE_IS_FATAL", tools->failure_is_fatal() ? "yes" : "")
+        .setenv("PALUDIS_LOG_TO_STDOUT", tools->log_to_stdout() ? "yes" : "")
         .setenv("PALUDIS_DIE_SUPPORTS_DASH_N",
                 tools->die_supports_dash_n() ? "yes" : "")
         .setenv("PALUDIS_UNPACK_FROM_VAR", environment_variables->env_distdir())

--- a/paludis/util/echo_functions.bash.in
+++ b/paludis/util/echo_functions.bash.in
@@ -57,7 +57,11 @@ paludis_ecmd()
 
     # don't try to avoid a newline for einfon. it gets horrible when logging
     # things, and einfon is abused more than it is used correctly.
-    echo -e "${prefix}${message}" >&2
+    if [ -n "${PALUDIS_LOG_TO_STDOUT}" ]; then
+        echo -e "${prefix}${message}"
+    else
+        echo -e "${prefix}${message}" >&2
+    fi
 
     if type perform_hook &>/dev/null ; then
         if [[ -n "${hook}" ]] ; then
@@ -113,7 +117,7 @@ elog()
 
 ewarn()
 {
-    paludis_ecmd \
+    PALUDIS_LOG_TO_STDOUT='' paludis_ecmd \
         "ewarn" \
         "ewarn" \
         "`echo -ne " ${COLOUR_WARN}*${COLOUR_NORMAL} "`" \
@@ -122,7 +126,7 @@ ewarn()
 
 eqawarn()
 {
-    paludis_ecmd \
+    PALUDIS_LOG_TO_STDOUT='' paludis_ecmd \
         "eqawarn" \
         "eqawarn" \
         "`echo -ne " ${COLOUR_WARN}*${COLOUR_NORMAL} "`" \
@@ -131,7 +135,7 @@ eqawarn()
 
 eerror()
 {
-    paludis_ecmd \
+    PALUDIS_LOG_TO_STDOUT='' paludis_ecmd \
         "eerror" \
         "eerror" \
         "`echo -ne " ${COLOUR_BAD}*${COLOUR_NORMAL} "`" \
@@ -170,7 +174,11 @@ _eend()
         msg="${COLOUR_BRACKET}[ ${COLOUR_BAD}!!${COLOUR_BRACKET} ]${COLOUR_NORMAL}"
     fi
 
-    echo -e "${PALUDIS_ENDCOL} ${msg}"
+    if [ -n "${PALUDIS_LOG_TO_STDOUT}" ]; then
+        echo -e "${PALUDIS_ENDCOL} ${msg}"
+    else
+        echo -e "${PALUDIS_ENDCOL} ${msg}" >&2
+    fi
 
     return ${retval}
 }


### PR DESCRIPTION
Previous EAPIs didn't specify where `elog` and friends were supposed to output to, so they typically logged to stdout.

That naturally mixes even important package manager messages with compile output, so `EAPI 7` defined that the output shall go to `stderr`.

We'll keep the output on `stdout` for `EAPI`s prior to `7`, and output to `stderr` for anything later.

Merging with a merge commit, since this PR consists of two commits.