### PR TITLE
Implement into override for domo in EAPI=7.

### DIFF
--- a/paludis/repositories/e/eapi.cc
+++ b/paludis/repositories/e/eapi.cc
@@ -254,6 +254,7 @@ namespace
                         n::doins_symlink() = destringify_key<bool>(k, "doins_symlink"),
                         n::doman_lang_filenames() = destringify_key<bool>(k, "doman_lang_filenames"),
                         n::doman_lang_filenames_overrides() = destringify_key<bool>(k, "doman_lang_filenames_overrides"),
+                        n::domo_respects_into() = destringify_key<bool>(k, "domo_respects_into"),
                         n::dosym_mkdir() = destringify_key<bool>(k, "dosym_mkdir"),
                         n::econf_extra_options() = k.get("econf_extra_options"),
                         n::econf_extra_options_help_dependent() = k.get("econf_extra_options_help_dependent"),

--- a/paludis/repositories/e/eapi.hh
+++ b/paludis/repositories/e/eapi.hh
@@ -70,6 +70,7 @@ namespace paludis
         typedef Name<struct name_doins_symlink> doins_symlink;
         typedef Name<struct name_doman_lang_filenames> doman_lang_filenames;
         typedef Name<struct name_doman_lang_filenames_overrides> doman_lang_filenames_overrides;
+        typedef Name<struct name_domo_respects_into> domo_respects_into;
         typedef Name<struct name_dosym_mkdir> dosym_mkdir;
         typedef Name<struct name_eapi> eapi;
         typedef Name<struct name_ebuild_bad_options> ebuild_bad_options;
@@ -500,6 +501,7 @@ namespace paludis
             NamedValue<n::doins_symlink, bool> doins_symlink;
             NamedValue<n::doman_lang_filenames, bool> doman_lang_filenames;
             NamedValue<n::doman_lang_filenames_overrides, bool> doman_lang_filenames_overrides;
+            NamedValue<n::domo_respects_into, bool> domo_respects_into;
             NamedValue<n::dosym_mkdir, bool> dosym_mkdir;
             NamedValue<n::econf_extra_options, std::string> econf_extra_options;
             NamedValue<n::econf_extra_options_help_dependent, std::string> econf_extra_options_help_dependent;

--- a/paludis/repositories/e/eapis/0.conf
+++ b/paludis/repositories/e/eapis/0.conf
@@ -287,6 +287,7 @@ dosym_mkdir = true
 failure_is_fatal = false
 die_supports_dash_n = false
 log_to_stdout = true
+domo_respects_into = true
 no_s_workdir_fallback = false
 use_with_enable_empty_third_argument = false
 best_has_version_host_root = false

--- a/paludis/repositories/e/eapis/7.conf
+++ b/paludis/repositories/e/eapis/7.conf
@@ -35,3 +35,4 @@ load_modules = ${load_modules} version_functions
 econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --with-sysroot::--with-sysroot=\${ESYSROOT:-/}
 
 log_to_stdout = false
+domo_respects_into = false

--- a/paludis/repositories/e/eapis/exheres-0.conf
+++ b/paludis/repositories/e/eapis/exheres-0.conf
@@ -365,6 +365,7 @@ doins_symlink = true
 failure_is_fatal = true
 die_supports_dash_n = false
 log_to_stdout = true
+domo_respects_into = true
 no_s_workdir_fallback = true
 use_with_enable_empty_third_argument = true
 fix_mtimes = true

--- a/paludis/repositories/e/eapis/paludis-1.conf
+++ b/paludis/repositories/e/eapis/paludis-1.conf
@@ -284,6 +284,7 @@ dodoc_r = false
 dosym_mkdir = false
 doins_symlink = false
 log_to_stdout = true
+domo_respects_into = true
 use_with_enable_empty_third_argument = true
 failure_is_fatal = false
 die_supports_dash_n = false

--- a/paludis/repositories/e/ebuild.cc
+++ b/paludis/repositories/e/ebuild.cc
@@ -259,6 +259,7 @@ EbuildCommand::operator() ()
                 tools->use_with_enable_empty_third_argument() ? "yes" : "")
         .setenv("PALUDIS_FAILURE_IS_FATAL", tools->failure_is_fatal() ? "yes" : "")
         .setenv("PALUDIS_LOG_TO_STDOUT", tools->log_to_stdout() ? "yes" : "")
+        .setenv("PALUDIS_DOMO_RESPECTS_INTO", tools->domo_respects_into() ? "yes" : "")
         .setenv("PALUDIS_DIE_SUPPORTS_DASH_N",
                 tools->die_supports_dash_n() ? "yes" : "")
         .setenv("PALUDIS_UNPACK_FROM_VAR", environment_variables->env_distdir())

--- a/paludis/repositories/e/ebuild/utils/domo
+++ b/paludis/repositories/e/ebuild/utils/domo
@@ -2,6 +2,7 @@
 # vim: set sw=4 sts=4 et :
 
 # Copyright (c) 2006 Stephen Bennett
+# Copyright (c) 2022 Mihai Moldovan
 #
 # Based in part upon domo from Portage, which is Copyright 1995-2005
 # Gentoo Foundation and distributed under the terms of the GNU General
@@ -31,8 +32,16 @@ if [[ ${#} -lt 1 ]]; then
     paludis_die_or_error "at least one argument needed"
 fi
 
-if [[ ! -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale" ]]; then
-    install -d "${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale" || paludis_die_or_error "could not create ${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale"
+typeset base_location="${!PALUDIS_IMAGE_DIR_VAR%/}/"
+if [[ -n "${PALUDIS_DOMO_RESPECTS_INTO}" ]]; then
+    base_location="${base_location}${DESTTREE#/}"
+else
+    base_location="${base_location}usr"
+fi
+base_location="${base_location}/share/locale"
+
+if [[ ! -d "${base_location}" ]]; then
+    install -d "${base_location}" || paludis_die_or_error "could not create ${base_location}"
 fi
 
 ret=0
@@ -40,7 +49,7 @@ ret=0
 for x in "$@"; do
     if [[ -e "${x}" ]]; then
         mytiny="$(basename "${x}")"
-        mydir="${!PALUDIS_IMAGE_DIR_VAR%/}/${DESTTREE#/}/share/locale/${mytiny%.*}/LC_MESSAGES"
+        mydir="${base_location}/${mytiny%.*}/LC_MESSAGES"
         if [[ ! -d "${mydir}" ]]; then
             install -d "${mydir}"
         fi


### PR DESCRIPTION
`EAPI=7` started disregarding a previous `into` call for `domo`, instead installing the provided files into a hardcoded location - `/usr/share/locales`.

The prefix (`/usr`) is replaced by whatever an `into` call specified in earlier EAPIs.