### PR TITLE
EAPI=7: implement controllable stripping.

### DIFF
--- a/paludis/repositories/e/do_install_action.cc
+++ b/paludis/repositories/e/do_install_action.cc
@@ -319,7 +319,7 @@ paludis::erepository::do_install_action(
         }
         else if (phase.option("strip"))
         {
-            if ((! id->eapi()->supported()->is_pbin()) && (! strip_restrict))
+            if ((! id->eapi()->supported()->is_pbin()))
             {
                 std::string libdir("lib");
                 FSPath root(destination->installed_root_key()
@@ -342,13 +342,15 @@ paludis::erepository::do_install_action(
                 EStripper stripper(make_named_values<EStripperOptions>(
                             n::compress_splits() = symbols_choice && symbols_choice->enabled() && ELikeSymbolsChoiceValue::should_compress(
                                 symbols_choice->parameter()),
+                            n::controllable_strip_dir() = package_builddir / "temp",
                             n::debug_dir() = package_builddir / "image" / "usr" / libdir / "debug",
                             n::dwarf_compression() = dwarf_compression && dwarf_compression->enabled(),
                             n::image_dir() = package_builddir / "image",
                             n::output_manager() = output_manager,
                             n::package_id() = id,
                             n::split() = symbols_choice && symbols_choice->enabled() && ELikeSymbolsChoiceValue::should_split(symbols_choice->parameter()),
-                            n::strip() = symbols_choice && symbols_choice->enabled() && ELikeSymbolsChoiceValue::should_strip(symbols_choice->parameter())
+                            n::strip_choice() = symbols_choice && symbols_choice->enabled() && ELikeSymbolsChoiceValue::should_strip(symbols_choice->parameter()),
+                            n::strip_restrict() = strip_restrict
                             ));
                 stripper.strip();
             }

--- a/paludis/repositories/e/e_stripper.cc
+++ b/paludis/repositories/e/e_stripper.cc
@@ -18,9 +18,12 @@
  */
 
 #include <paludis/repositories/e/e_stripper.hh>
+#include <paludis/repositories/e/e_repository_id.hh>
+#include <paludis/repositories/e/eapi.hh>
 #include <paludis/util/pimp-impl.hh>
 #include <paludis/util/make_named_values.hh>
 #include <paludis/output_manager.hh>
+#include <paludis/package_id.hh>
 #include <ostream>
 
 using namespace paludis;
@@ -43,11 +46,14 @@ namespace paludis
 EStripper::EStripper(const EStripperOptions & options) :
     Stripper(make_named_values<StripperOptions>(
                 n::compress_splits() = options.compress_splits(),
+                n::controllable_strip() = static_cast<const ERepositoryID &>(*options.package_id()).eapi()->supported()->tools_options()->controllable_strip(),
+                n::controllable_strip_dir() = options.controllable_strip_dir(),
                 n::debug_dir() = options.debug_dir(),
                 n::dwarf_compression() = options.dwarf_compression(),
                 n::image_dir() = options.image_dir(),
                 n::split() = options.split(),
-                n::strip() = options.strip()
+                n::strip_choice() = options.strip_choice(),
+                n::strip_restrict() = options.strip_restrict()
                 )),
     _imp(options)
 {

--- a/paludis/repositories/e/e_stripper.hh
+++ b/paludis/repositories/e/e_stripper.hh
@@ -30,6 +30,7 @@ namespace paludis
     namespace n
     {
         typedef Name<struct name_compress_splits> compress_splits;
+        typedef Name<struct name_controllable_strip_dir> controllable_strip_dir;
         typedef Name<struct name_debug_dir> debug_dir;
         typedef Name<struct name_dwarf_compression> dwarf_compression;
         typedef Name<struct name_image_dir> image_dir;
@@ -44,13 +45,15 @@ namespace paludis
         struct EStripperOptions
         {
             NamedValue<n::compress_splits, bool> compress_splits;
+            NamedValue<n::controllable_strip_dir, FSPath> controllable_strip_dir;
             NamedValue<n::debug_dir, FSPath> debug_dir;
             NamedValue<n::dwarf_compression, bool> dwarf_compression;
             NamedValue<n::image_dir, FSPath> image_dir;
             NamedValue<n::output_manager, std::shared_ptr<OutputManager> > output_manager;
             NamedValue<n::package_id, std::shared_ptr<const PackageID> > package_id;
             NamedValue<n::split, bool> split;
-            NamedValue<n::strip, bool> strip;
+            NamedValue<n::strip_choice, bool> strip_choice;
+            NamedValue<n::strip_restrict, bool> strip_restrict;
         };
 
         class EStripper :

--- a/paludis/repositories/e/eapi.cc
+++ b/paludis/repositories/e/eapi.cc
@@ -251,6 +251,7 @@ namespace
     {
         return std::make_shared<EAPIToolsOptions>(make_named_values<EAPIToolsOptions>(
                         n::best_has_version_host_root() = destringify_key<bool>(k, "best_has_version_host_root"),
+                        n::controllable_strip() = destringify_key<bool>(k, "controllable_strip"),
                         n::die_supports_dash_n() = destringify_key<bool>(k, "die_supports_dash_n"),
                         n::dodoc_r() = destringify_key<bool>(k, "dodoc_r"),
                         n::doins_symlink() = destringify_key<bool>(k, "doins_symlink"),

--- a/paludis/repositories/e/eapi.hh
+++ b/paludis/repositories/e/eapi.hh
@@ -56,6 +56,7 @@ namespace paludis
         typedef Name<struct name_build_depend> build_depend_host;
         typedef Name<struct name_can_be_pbin> can_be_pbin;
         typedef Name<struct name_choices_options> choices_options;
+        typedef Name<struct name_controllable_strip> controllable_strip;
         typedef Name<struct name_defined_phases> defined_phases;
         typedef Name<struct name_dependencies> dependencies;
         typedef Name<struct name_dependency_labels> dependency_labels;
@@ -500,6 +501,7 @@ namespace paludis
         struct EAPIToolsOptions
         {
             NamedValue<n::best_has_version_host_root, bool> best_has_version_host_root;
+            NamedValue<n::controllable_strip, bool> controllable_strip;
             NamedValue<n::die_supports_dash_n, bool> die_supports_dash_n;
             NamedValue<n::dodoc_r, bool> dodoc_r;
             NamedValue<n::doins_symlink, bool> doins_symlink;

--- a/paludis/repositories/e/eapis/0.conf
+++ b/paludis/repositories/e/eapis/0.conf
@@ -290,6 +290,7 @@ failure_is_fatal = false
 die_supports_dash_n = false
 log_to_stdout = true
 domo_respects_into = true
+controllable_strip = false
 no_s_workdir_fallback = false
 use_with_enable_empty_third_argument = false
 best_has_version_host_root = false

--- a/paludis/repositories/e/eapis/7.conf
+++ b/paludis/repositories/e/eapis/7.conf
@@ -36,6 +36,7 @@ econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --wit
 
 log_to_stdout = false
 domo_respects_into = false
+controllable_strip = true
 
 env_desttree = PALUDIS_INTERNAL_DESTTREE
 env_insdesttree = PALUDIS_INTERNAL_INSDESTTREE

--- a/paludis/repositories/e/eapis/exheres-0.conf
+++ b/paludis/repositories/e/eapis/exheres-0.conf
@@ -368,6 +368,7 @@ failure_is_fatal = true
 die_supports_dash_n = false
 log_to_stdout = true
 domo_respects_into = true
+controllable_strip = false
 no_s_workdir_fallback = true
 use_with_enable_empty_third_argument = true
 fix_mtimes = true

--- a/paludis/repositories/e/eapis/paludis-1.conf
+++ b/paludis/repositories/e/eapis/paludis-1.conf
@@ -287,6 +287,7 @@ dosym_mkdir = false
 doins_symlink = false
 log_to_stdout = true
 domo_respects_into = true
+controllable_strip = false
 use_with_enable_empty_third_argument = true
 failure_is_fatal = false
 die_supports_dash_n = false

--- a/paludis/repositories/e/ebuild.cc
+++ b/paludis/repositories/e/ebuild.cc
@@ -260,6 +260,7 @@ EbuildCommand::operator() ()
         .setenv("PALUDIS_FAILURE_IS_FATAL", tools->failure_is_fatal() ? "yes" : "")
         .setenv("PALUDIS_LOG_TO_STDOUT", tools->log_to_stdout() ? "yes" : "")
         .setenv("PALUDIS_DOMO_RESPECTS_INTO", tools->domo_respects_into() ? "yes" : "")
+        .setenv("PALUDIS_CONTROLLABLE_STRIP", tools->controllable_strip() ? "yes" : "")
         .setenv("PALUDIS_DIE_SUPPORTS_DASH_N",
                 tools->die_supports_dash_n() ? "yes" : "")
         .setenv("PALUDIS_UNPACK_FROM_VAR", environment_variables->env_distdir())

--- a/paludis/repositories/e/ebuild/utils/7/CMakeLists.txt
+++ b/paludis/repositories/e/ebuild/utils/7/CMakeLists.txt
@@ -12,6 +12,7 @@ install(PROGRAMS
           "${CMAKE_CURRENT_BINARY_DIR}/dolib"
           "${CMAKE_CURRENT_SOURCE_DIR}/dolib.a"
           "${CMAKE_CURRENT_SOURCE_DIR}/dolib.so"
+          "${CMAKE_CURRENT_SOURCE_DIR}/dostrip"
           "${CMAKE_CURRENT_SOURCE_DIR}/banned_in_eapi_7"
         DESTINATION
           "${CMAKE_INSTALL_FULL_LIBEXECDIR}/paludis/utils/7")

--- a/paludis/repositories/e/ebuild/utils/7/dostrip
+++ b/paludis/repositories/e/ebuild/utils/7/dostrip
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# vim: set sw=4 sts=4 et :
+
+# Copyright (c) 2009 Ciaran McCreesh
+# Copyright (c) 2022 Mihai Moldovan
+#
+# This file is part of the Paludis package manager. Paludis is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation; either version
+# 2 of the License, or (at your option) any later version.
+#
+# Paludis is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+source "${PALUDIS_EBUILD_DIR}"/die_functions.bash
+
+if [[ -z "${PALUDIS_CONTROLLABLE_STRIP}" ]]; then
+    typeset color_red=$'\e[31;01m'
+    typeset color_normal=$'\e[0m'
+    typeset my_name="$(basename "${0}")"
+
+    printf '%s!!! Ebuild bug: '%s' not supported in this EAPI%s\n' "${color_red}" "${my_name}" "${color_normal}"
+    printf '%s: making ebuild PID %s exit with error\n' "${my_name}" "${EBUILD_KILL_PID}" 1>&2
+    kill -s 'SIGUSR1' "${EBUILD_KILL_PID}"
+
+    exit '123'
+fi
+
+if [[ ! -d "${!PALUDIS_TEMP_DIR_VAR}" ]]; then
+    paludis_die_or_error "\${${PALUDIS_TEMP_DIR_VAR}} not valid; aborting" >&2
+fi
+
+if [[ '1' -gt "${#}" ]]; then
+    paludis_die_or_error 'at least one argument needed'
+fi
+
+typeset -i exclude='0'
+
+if [[ '-x' = "${1}" ]]; then
+    exclude='1'
+    shift
+fi
+
+typeset list_file="${!PALUDIS_TEMP_DIR_VAR}/dostrip."
+if [[ '0' -eq "${exclude}" ]]; then
+    list_file="${list_file}include"
+else
+    list_file="${list_file}exclude"
+fi
+
+typeset pathspec=''
+for pathspec in "${@}"; do
+    # If ${pathspec} is absolute (which it really should be), force it to be
+    # relative to avoid double slashes.
+    printf '%s\0' "${ED}/${pathspec#/}" >> "${list_file}"
+done
+
+exit '0'

--- a/paludis/repositories/e/ebuild_id.cc
+++ b/paludis/repositories/e/ebuild_id.cc
@@ -1620,15 +1620,25 @@ EbuildID::add_build_options(const std::shared_ptr<Choices> & choices) const
     {
         bool may_be_unrestricted_strip(true);
 
-        /* if we unconditionally restrict an action, don't add / force mask
+        /*
+         * if we unconditionally restrict an action, don't add / force mask
          * a build option for it. but if we conditionally restrict it, do,
-         * to avoid weirdness in cases like RESTRICT="test? ( test )." */
+         * to avoid weirdness in cases like RESTRICT="test? ( test )".
+         *
+         * However, some elements, like strip, might be restricted, but
+         * can be overridden by other things, like the new controllable
+         * strip feature.
+         * For such cases, apply overrides.
+         */
         if (restrict_key())
         {
             UnconditionalRestrictFinder f;
             restrict_key()->parse_value()->top()->accept(f);
+
+            bool strip_override = eapi()->supported()->tools_options()->controllable_strip();
+
             mask_tests = f.s.end() != f.s.find("test");
-            may_be_unrestricted_strip = f.s.end() == f.s.find("strip");
+            may_be_unrestricted_strip = (f.s.end() == f.s.find("strip")) || strip_override;
         }
 
         /* symbols */

--- a/paludis/repositories/unpackaged/unpackaged_stripper.cc
+++ b/paludis/repositories/unpackaged/unpackaged_stripper.cc
@@ -43,11 +43,14 @@ namespace paludis
 UnpackagedStripper::UnpackagedStripper(const UnpackagedStripperOptions & options) :
     Stripper(make_named_values<StripperOptions>(
                 n::compress_splits() = options.compress_splits(),
+                n::controllable_strip() = false,
+                n::controllable_strip_dir() = "",
                 n::debug_dir() = options.debug_dir(),
                 n::dwarf_compression() = options.dwarf_compression(),
                 n::image_dir() = options.image_dir(),
                 n::split() = options.split(),
-                n::strip() = options.strip()
+                n::strip_choice() = options.strip(),
+                n::strip_restrict() = false
             )),
     _imp(options)
 {

--- a/paludis/stripper.hh
+++ b/paludis/stripper.hh
@@ -33,21 +33,27 @@ namespace paludis
     namespace n
     {
         typedef Name<struct name_compress_splits> compress_splits;
+        typedef Name<struct name_controllable_strip> controllable_strip;
+        typedef Name<struct name_controllable_strip_dir> controllable_strip_dir;
         typedef Name<struct name_debug_dir> debug_dir;
         typedef Name<struct name_dwarf_compression> dwarf_compression;
         typedef Name<struct name_image_dir> image_dir;
         typedef Name<struct name_split> split;
-        typedef Name<struct name_strip> strip;
+        typedef Name<struct name_strip_choice> strip_choice;
+        typedef Name<struct name_strip_restrict> strip_restrict;
     }
 
     struct StripperOptions
     {
         NamedValue<n::compress_splits, bool> compress_splits;
+        NamedValue<n::controllable_strip, bool> controllable_strip;
+        NamedValue<n::controllable_strip_dir, FSPath> controllable_strip_dir;
         NamedValue<n::debug_dir, FSPath> debug_dir;
         NamedValue<n::dwarf_compression, bool> dwarf_compression;
         NamedValue<n::image_dir, FSPath> image_dir;
         NamedValue<n::split, bool> split;
-        NamedValue<n::strip, bool> strip;
+        NamedValue<n::strip_choice, bool> strip_choice;
+        NamedValue<n::strip_restrict, bool> strip_restrict;
     };
 
     class PALUDIS_VISIBLE StripperError :
@@ -62,6 +68,9 @@ namespace paludis
         private:
             Pimp<Stripper> _imp;
 
+            void populate_list(const bool);
+            bool part_of_list(const FSPath &, const bool);
+
         protected:
             virtual void on_enter_dir(const FSPath &) = 0;
             virtual void on_leave_dir(const FSPath &) = 0;
@@ -71,7 +80,7 @@ namespace paludis
             virtual void on_dwarf_compress(const FSPath &) = 0;
             virtual void on_unknown(const FSPath &) = 0;
 
-            virtual void do_dir_recursive(const FSPath &);
+            virtual void do_dir_recursive(const FSPath &, const bool);
 
             virtual std::string file_type(const FSPath &);
 

--- a/paludis/stripper_TEST.cc
+++ b/paludis/stripper_TEST.cc
@@ -69,11 +69,14 @@ TEST(Stripper, Works)
 {
     TestStripper s(make_named_values<StripperOptions>(
                 n::compress_splits() = false,
+                n::controllable_strip() = false,
+                n::controllable_strip_dir() = "",
                 n::debug_dir() = FSPath("stripper_TEST_dir/image").realpath() / "usr" / "lib" / "debug",
                 n::dwarf_compression() = false,
                 n::image_dir() = FSPath("stripper_TEST_dir/image").realpath(),
                 n::split() = true,
-                n::strip() = true
+                n::strip_choice() = true,
+                n::strip_restrict() = false
             ));
     s.strip();
 


### PR DESCRIPTION
`EAPI=7` introduces the concept of controllable stripping, implemented through the new `dostrip` utility.

`dostrip` works with two lists: an include list and an exclude list.

Unless a package is strip restricted, the whole image directory is added to the stripping list by default. Users can then use `dostrip -x` to exclude specific files or directories from being stripped.

Excluding a directory will also exclude all files and subdirectories within that directory.

Specific files and directories can be be re-added to the list of files to strip using an argumentless `dostrip` call.

If a package is strip-restricted, no files are stripped by default.

Merging with a merge commit, since this PR consists of multiple commits.