### PR TITLE
doins: add curly braces to $@ variable. (NFC)

### DIFF
--- a/paludis/repositories/e/ebuild/utils/doins
+++ b/paludis/repositories/e/ebuild/utils/doins
@@ -59,7 +59,7 @@ fi
 
 ret='0'
 
-for x in "$@"; do
+for x in "${@}"; do
     if [[ -L "${x}" ]]; then
         if [[ -n "${PALUDIS_DOINS_SYMLINK}" ]] ; then
             ln -s "$(readlink "${x}" )" "${!PALUDIS_IMAGE_DIR_VAR}${INSDESTTREE}/$(basename "${x}")" || ret='2'


### PR DESCRIPTION
Just syncing up the code with my `wip/*` branches. This change unfortunately fell through the cracks in 1abe27d44e085bd997b8bd73425f93bea1584026.