### PR TITLE
EAPI=7: fix negative USE feature.

### DIFF
--- a/paludis/repositories/e/traditional_profile.cc
+++ b/paludis/repositories/e/traditional_profile.cc
@@ -465,7 +465,7 @@ namespace
         for (const auto & x : *_imp->use_expand)
             _imp->known_choice_value_names.insert(std::make_pair(tolower(x), std::make_shared<Set<UnprefixedChoiceName>>()));
 
-        for (const auto & u : _imp->use)
+        for (const auto & u : FlagIdStatusMap (_imp->use.begin (), _imp->use.end ()))
         {
             if (! stringify(u.first.first).empty())
             {


### PR DESCRIPTION
Merge ae45b9d215981f877437d032b116a35ea0ceb2be accidentally broke the EAPI=7 negative USE feature by overwriting a code line with an upstream change, but not taking our changes into account.

Fix that by correctly merging the code bases.

Closes: https://github.com/MageSlayer/paludis-gentoo-patches/pull/60