### PR TITLE
EAPI=7: miscellaneous test updates.

### DIFF
--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -95,7 +95,7 @@ namespace
 TEST(ERepository, InstallEAPI7)
 {
     FSPath cwd(FSPath::cwd());
-    FSPath test_dir(cwd / (std::string(::testing::UnitTest::GetInstance()->current_test_case()->name()) + '.' + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +"_dir"));
+    // FSPath test_dir(cwd / (std::string(::testing::UnitTest::GetInstance()->current_test_case()->name()) + '.' + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +"_dir"));
     TestEnvironment env;
     std::shared_ptr<Map<std::string, std::string> > keys(std::make_shared<Map<std::string, std::string>>());
     keys->insert("format", "e");
@@ -222,7 +222,8 @@ TEST(ERepository, InstallEAPI7)
     }
 
     {
-        setenv("PALUDIS_USER_PATCHES", (test_dir/ "e_repository_TEST_7_dir/root/var/paludis/user_patches").c_str() , 1);
+        setenv("PALUDIS_USER_PATCHES", stringify(cwd / "e_repository_TEST_7_dir" /
+                                                 "root" / "var" / "paludis" / "user_patches").c_str() , 1);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/eapply-user-git-diff-support-7",
                                 &env, { })), nullptr, { }))]->last());

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -173,7 +173,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        ASSERT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -826,7 +826,7 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        EXPECT_TRUE(pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -141,7 +141,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_THROW(id->perform_action(action), ActionFailedError);
+        EXPECT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {
@@ -155,7 +155,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -164,7 +164,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_THROW(id->perform_action(action), ActionFailedError);
+        EXPECT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {
@@ -173,7 +173,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_THROW(id->perform_action(action), ActionFailedError);
+        EXPECT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {
@@ -182,7 +182,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_THROW(id->perform_action(action), ActionFailedError);
+        EXPECT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {
@@ -191,7 +191,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -200,7 +200,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -209,7 +209,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -218,7 +218,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -228,7 +228,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
         unsetenv("PALUDIS_USER_PATCHES");
     }
 
@@ -239,7 +239,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -248,7 +248,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -258,7 +258,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -268,7 +268,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -283,7 +283,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -292,7 +292,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_THROW(id->perform_action(action), ActionFailedError);
+        EXPECT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {
@@ -305,7 +305,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_TRUE(!!id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("build_options:optional_tests")));
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -314,7 +314,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -324,7 +324,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -333,7 +333,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -342,7 +342,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -351,7 +351,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        EXPECT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -361,7 +361,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -380,7 +380,7 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -400,6 +400,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 }

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -409,6 +409,15 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
 
+        /*
+         * We need to invalidate the repository to clear previous choices if
+         * we want to run the pretend action multiple times with different
+         * choice values.
+         *
+         * Nothing else should be affected. Hopefully.
+         */
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -433,6 +442,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -456,6 +467,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        repo->invalidate();
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
@@ -481,6 +494,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -504,6 +519,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        repo->invalidate();
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
@@ -529,6 +546,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -578,6 +597,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -603,6 +624,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -627,6 +650,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        repo->invalidate();
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
@@ -653,6 +678,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -678,6 +705,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -702,6 +731,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        repo->invalidate();
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
@@ -728,6 +759,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -752,6 +785,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        repo->invalidate();
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
@@ -778,6 +813,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
 
+        repo->invalidate();
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
                                 &env, { })), nullptr, { }))]->last());
@@ -802,6 +839,8 @@ TEST(ERepository, InstallEAPI7)
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        repo->invalidate();
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -395,7 +395,151 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -102,7 +102,7 @@ TEST(ERepository, InstallEAPI7)
     keys->insert("format", "e");
     keys->insert("names_cache", "/var/empty");
     keys->insert("location", stringify(FSPath::cwd() / "e_repository_TEST_7_dir" / "repo"));
-    keys->insert("profiles", stringify(FSPath::cwd() / "e_repository_TEST_7_dir" / "repo/profiles/profile"));
+    keys->insert("profiles", stringify(FSPath::cwd() / "e_repository_TEST_7_dir" / "repo/profiles/profile/child_profile"));
     keys->insert("layout", "traditional");
     keys->insert("eapi_when_unknown", "0");
     keys->insert("eapi_when_unspecified", "0");
@@ -376,6 +376,21 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        setenv("PARENT_VAR_TO_UNSET", "foo", 1);
+        setenv("CHILD_VAR_TO_UNSET", "bar", 1);
+        setenv("PARENT_VAR_TO_VANISH", "baz", 1);
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/env-unset-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_NO_THROW(id->perform_action(action));
+        unsetenv("PARENT_VAR_TO_UNSET");
+        unsetenv("CHILD_VAR_TO_UNSET");
+        unsetenv("PARENT_VAR_TO_VANISH");
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -150,6 +150,7 @@ TEST(ERepository, InstallEAPI7)
         auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](std::shared_ptr<Repository> cur_repo){return (cur_repo->name().value()=="installed");})); // >= C++11
         installed_repos->add_version("cat", "pretend-installed", "0");
         installed_repos->add_version("cat", "pretend-installed", "1");
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/best-version-7",
                                 &env, { })),nullptr,{ }))]->last());
@@ -274,10 +275,21 @@ TEST(ERepository, InstallEAPI7)
     }
 
     {
+        /*
+         * Adding the packages again will lead to an internal exception.
+         * Thus, don't do this here.
+         *
+         * Note that we want to only skip this for the "old-style" testing
+         * layout, where test cases re-use data from previous ones.
+         * If the environment/repository metadata was clean, we'd have to
+         * actually add the fake packages.
+         */
+        /*
         auto repos = env.repositories();
         auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](std::shared_ptr<Repository> cur_repo){return (cur_repo->name().value()=="installed");})); // >= C++11
         installed_repos->add_version("cat", "pretend-installed", "0");
         installed_repos->add_version("cat", "pretend-installed", "1");
+        */
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/has-version-7",

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -376,7 +376,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        EXPECT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(pretend_action.failed());
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -297,16 +297,17 @@ TEST(ERepository, InstallEAPI7)
     }
 
     {
-        auto env_copy = env;
-        env_copy.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), true);
+        env.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), true);
 
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/nonfatal-external-and-function-7",
-                                &env_copy, { })), nullptr, { }))]->last());
+                                &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_TRUE(!!id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("build_options:optional_tests")));
         EXPECT_NO_THROW(id->perform_action(action));
+
+        env.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), false);
     }
 
     {
@@ -366,14 +367,14 @@ TEST(ERepository, InstallEAPI7)
     }
 
     {
-        auto env_copy = env;
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
-        const std::shared_ptr<const PackageID> id(*env_copy[selection::RequireExactlyOne(generator::Matches(
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
-                                &env_copy, { })), nullptr, { }))]->last());
+                                &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
@@ -382,17 +383,22 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
     }
 
     {
-        auto env_copy = env;
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
-                                &env_copy, { })), nullptr, { }))]->last());
+                                &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
@@ -402,5 +408,10 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
     }
 }

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -429,6 +429,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. a? (foo) is true.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -455,6 +457,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. b? (bar) is true.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -481,6 +485,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. both a? (foo) and b? (bar) are true.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -665,6 +671,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. a? (foo) is true, b? (bar) is false.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -773,6 +781,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. a? (foo) is false, b? (bar) is true.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -800,6 +810,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. a? (foo) is true, b? (bar) is false.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -827,6 +839,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+        // FIXME: fails, but should not. a? (foo) is false, b? (bar) is true.
+        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -94,6 +94,8 @@ namespace
 
 TEST(ERepository, InstallEAPI7)
 {
+    FSPath cwd(FSPath::cwd());
+    FSPath test_dir(cwd / (std::string(::testing::UnitTest::GetInstance()->current_test_case()->name()) + '.' + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +"_dir"));
     TestEnvironment env;
     std::shared_ptr<Map<std::string, std::string> > keys(std::make_shared<Map<std::string, std::string>>());
     keys->insert("format", "e");
@@ -135,47 +137,186 @@ TEST(ERepository, InstallEAPI7)
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions-7",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/assert-in-subshell-7",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        EXPECT_THROW(id->perform_action(action), ActionFailedError);
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        auto repos = env.repositories();
+        auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](auto repo){return (repo->name().value()=="installed");})); // >= C++11
+        installed_repos->add_version("cat", "pretend-installed", "0");
+        installed_repos->add_version("cat", "pretend-installed", "1");
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/best-version-7",
+                                &env, { })),nullptr,{ }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
     }
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions2-7",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/die-in-subshell-7",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        EXPECT_THROW(id->perform_action(action), ActionFailedError);
+        ASSERT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions3-7",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-dohtml-7",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(action);
+        ASSERT_NO_THROW(id->perform_action(action));
     }
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions4-7",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-dolib-7",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        EXPECT_THROW(id->perform_action(action), ActionFailedError);
+        ASSERT_NO_THROW(id->perform_action(action));
     }
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions5-7",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-dolib-rep-7",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(action);
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/changed-domo-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/added-dostrip-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/eapply-git-diff-support-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        setenv("PALUDIS_USER_PATCHES", (test_dir/ "e_repository_TEST_7_dir/root/var/paludis/user_patches").c_str() , 1);
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/eapply-user-git-diff-support-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+        unsetenv("PALUDIS_USER_PATCHES");
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/ebegin-not-to-stdout-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                      PackageDepSpec(parse_user_package_dep_spec("=cat/econf-added-options-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                      PackageDepSpec(parse_user_package_dep_spec("=cat/eend-not-to-stdout-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                      PackageDepSpec(parse_user_package_dep_spec("=cat/eqawarn-not-to-stdout-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        auto repos = env.repositories();
+        auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](auto repo){return (repo->name().value()=="installed");})); // >= C++11
+        installed_repos->add_version("cat", "pretend-installed", "0");
+        installed_repos->add_version("cat", "pretend-installed", "1");
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/has-version-7",
+                                &env,{ })),nullptr,{ }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-libopts-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        auto env_copy = env;
+        env_copy.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/nonfatal-external-and-function-7",
+                                &env_copy, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(!!id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("build_options:optional_tests")));
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/removed-eclassdir-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
     }
 
     {
@@ -185,6 +326,7 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(action);
+        ASSERT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -193,6 +335,73 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(action);
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/prefix-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/changed-vars-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-dep-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        auto env_copy = env;
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+        const std::shared_ptr<const PackageID> id(*env_copy[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-or-7",
+                                &env_copy, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        auto env_copy = env;
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env_copy, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
     }
 }

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -56,6 +56,7 @@
 #include <functional>
 #include <set>
 #include <string>
+#include <algorithm>
 
 #include "config.h"
 
@@ -146,7 +147,7 @@ TEST(ERepository, InstallEAPI7)
 
     {
         auto repos = env.repositories();
-        auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](auto repo){return (repo->name().value()=="installed");})); // >= C++11
+        auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](std::shared_ptr<Repository> cur_repo){return (cur_repo->name().value()=="installed");})); // >= C++11
         installed_repos->add_version("cat", "pretend-installed", "0");
         installed_repos->add_version("cat", "pretend-installed", "1");
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
@@ -274,7 +275,7 @@ TEST(ERepository, InstallEAPI7)
 
     {
         auto repos = env.repositories();
-        auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](auto repo){return (repo->name().value()=="installed");})); // >= C++11
+        auto installed_repos = std::dynamic_pointer_cast<FakeInstalledRepository>(*std::find_if(repos.begin(), repos.end(), [](std::shared_ptr<Repository> cur_repo){return (cur_repo->name().value()=="installed");})); // >= C++11
         installed_repos->add_version("cat", "pretend-installed", "0");
         installed_repos->add_version("cat", "pretend-installed", "1");
 

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -550,6 +550,231 @@ TEST(ERepository, InstallEAPI7)
     {
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
 
@@ -559,12 +784,37 @@ TEST(ERepository, InstallEAPI7)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
-        EXPECT_FALSE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        EXPECT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), false);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), false);
+    }
+
+    {
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("foo"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("bar"), true);
+
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/selectors-xor-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("a"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("b"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("foo"))->enabled());
+        EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        EXPECT_TRUE(pretend_action.failed());
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -292,8 +292,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        ASSERT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -141,8 +141,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        ASSERT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -338,7 +338,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(action);
+        id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
     }
 

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -377,6 +377,9 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(pretend_action.failed());
+        // FIXME: doesn't fail, but should.
+        //        Reason is known: EAPI=8 behavior for empty OR groups not yet
+        //        implemented.
     }
 
     {
@@ -396,6 +399,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(pretend_action.failed());
+        // FIXME: doesn't fail, but should.
+        //        Reason as above.
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -429,8 +434,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. a? (foo) is true.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -457,8 +460,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. b? (bar) is true.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -485,8 +486,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_TRUE(id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("bar"))->enabled());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. both a? (foo) and b? (bar) are true.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -590,6 +589,8 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(pretend_action.failed());
+        // FIXME: doesn't fail, but should.
+        //        Reason: missing implementation of empty XOR groups for EAPI=8.
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -671,8 +672,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. a? (foo) is true, b? (bar) is false.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -781,8 +780,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. a? (foo) is false, b? (bar) is true.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -810,8 +807,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. a? (foo) is true, b? (bar) is false.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);
@@ -839,8 +834,6 @@ TEST(ERepository, InstallEAPI7)
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
-        // FIXME: fails, but should not. a? (foo) is false, b? (bar) is true.
-        //        Additionally, can't reproduce the failure manually?!
 
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("a"), false);
         env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("b"), false);

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -216,6 +216,15 @@ TEST(ERepository, InstallEAPI7)
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/added-dostrip-strip-restrict-7",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_NO_THROW(id->perform_action(action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/eapply-git-diff-support-7",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));

--- a/paludis/repositories/e/e_repository_TEST_7.cc
+++ b/paludis/repositories/e/e_repository_TEST_7.cc
@@ -182,7 +182,7 @@ TEST(ERepository, InstallEAPI7)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("7", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(action));
+        ASSERT_THROW(id->perform_action(action), ActionFailedError);
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -265,7 +265,7 @@ src_compile() {
 
 src_install() {
     dobin test
-    dostrip -x test || die 'dostrip -x failed'
+    dostrip -x '/usr/bin/test' || die 'dostrip -x failed'
 }
 
 pkg_postinst() {

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -288,14 +288,16 @@ KEYWORDS="test"
 S=${WORKDIR}
 
 src_unpack() {
-    echo first >file || die
+    echo first >file || die 'normal setup'
+    echo 'thank you' >rename_me || die 'rename setup'
 }
 
 src_prepare() {
-    [[ -n "$(declare -F eapply)" ]] || die 'not defined'
+    eapply "${FILESDIR}"/first || die 'eapply normal'
+    [[ "$(< file)" == 'second' ]] || die 'file normal'
 
-    eapply "${FILESDIR}"/first || die 'eapply'
-    [[ "$(< file)" == 'second' ]] || die 'file'
+    eapply "${FILESDIR}"/rename || die 'eapply rename'
+    [[ "$(< renamed_you)" == 'thank you' ]] || die 'file rename'
 }
 END
 cat << 'END' > cat/eapply-git-diff-support/files/first
@@ -306,6 +308,12 @@ index 9c59e24..e019be0 100644
 @@ -1 +1 @@
 -first
 +second
+END
+cat << 'END' > cat/eapply-git-diff-support/files/rename
+diff --git a/rename_me b/renamed_you
+similarity index 100%
+rename from rename_me
+rename to renamed_you
 END
 
 # eapply_user GNU patch 2.7 guaranteed, git patches supported

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -331,16 +331,14 @@ KEYWORDS="test"
 S=${WORKDIR}
 
 src_unpack() {
-    echo "${PALUDIS_USER_PATCHES}"
-    echo first >file || die
+    echo first >file || die 'normal setup'
+    echo 'thank you' >rename_me || die 'rename setup'
 }
 
 src_prepare() {
-    [[ -n "$(declare -F eapply_user)" ]] || die 'not defined'
-
     eapply_user || die 'eapply_user'
-    cat file
-    [[ "$(< file)" == 'second' ]] || die 'patch failed'
+    [[ "$(< file)" == 'second' ]] || die 'patch failed normal'
+    [[ "$(< renamed_you)" == 'thank you' ]] || die 'patch failed rename'
 }
 END
 mkdir -p "../root/var/paludis/user_patches/cat/eapply-user-git-diff-support-7"
@@ -352,6 +350,10 @@ index 9c59e24..e019be0 100644
 @@ -1 +1 @@
 -first
 +second
+diff --git a/rename_me b/renamed_you
+similarity index 100%
+rename from rename_me
+rename to renamed_you
 END
 
 # ebegin no longer outputs to stdout

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -385,7 +385,8 @@ HOMEPAGE="http://example.com/"
 SRC_URI=""
 SLOT="0"
 IUSE="spork"
-CTARGET="i386-badger-linux-gnu"
+CBUILD="i286-banana-linux-gnu"
+CTARGET="i386-kiwi-linux-gnu"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
@@ -395,29 +396,51 @@ src_prepare(){
     cat <<'EOF' > configure
 #!/bin/sh
 
-if echo "$@" | grep -q 'help' ; then
-    echo --build
-    echo --target
-    echo --with-sysroot
-    exit 0
+param=''
+for param in "${@}"; do
+    if [ '--help' = "${param}" ]; then
+        printf '%s\n' '--build'
+        printf '%s\n' '--target'
+        printf '%s\n' '--with-sysroot'
+        exit 0
+    fi
+done
+
+param=''
+build='0'
+target='0'
+withsysroot='0'
+for param in "${@}"; do
+    if [ "--build=${CBUILD}" = "${param}" ]; then
+        build='1'
+    fi
+
+    if [ "--target=${CTARGET}" = "${param}" ]; then
+        target='1'
+    fi
+
+    if [ '--with-sysroot=${ESYSROOT:-/}' = "${param}" ]; then
+        withsysroot='1'
+    fi
+
+    if [ '1' = "${build}" ] && [ '1' = "${target}" ] && [ '1' = "${withsysroot}" ]; then
+        exit '0'
+    fi
+done
+
+if [ '0' = "${build}" ]; then
+    printf '%s missing\n' '--build'
 fi
 
-if ! echo "$@" | grep -q 'build' ; then
-    echo --build missing
-    exit 1
+if [ '0' = "${target}" ]; then
+    printf '%s missing\n' '--target'
 fi
 
-if ! echo "$@" | grep -q 'target' ; then
-    echo --target missing
-    exit 1
+if [ '0' = "${withsysroot}" ]; then
+    printf '%s missing\n' '--with-sysroot'
 fi
 
-if ! echo "$@" | grep -q 'with-sysroot' ; then
-    echo --with-sysroot missing
-    exit 1
-fi
-
-exit 0
+exit '1'
 EOF
 
     chmod +x configure

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -66,14 +66,14 @@ S="${WORKDIR}"
 
 pkg_setup() {
     (
-        test
+        test_func
     )
 }
 
-test() {
+test_func() {
     (
         true | false | true
-        assert test
+        assert 'test_func'
     )
 }
 END

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # vim: set ft=sh sw=4 sts=4 et :
 
-mkdir e_repository_TEST_7_dir || exit 1
-cd e_repository_TEST_7_dir || exit 1
+set -e
+
+mkdir e_repository_TEST_7_dir
+cd e_repository_TEST_7_dir
 
 mkdir -p root/etc
 
@@ -10,15 +12,24 @@ mkdir -p vdb
 touch vdb/THISISTHEVDB
 
 mkdir -p build
-ln -s build symlinked_build
 
 mkdir -p distdir
-gzip -c <<<test >distdir/test.gz
 
-mkdir -p repo/{profiles/profile,metadata,eclass} || exit 1
-cd repo || exit 1
-echo "test-repo" >> profiles/repo_name || exit 1
-echo "cat" >> profiles/categories || exit 1
+mkdir -p repo/{profiles/profile,metadata,eclass}
+cd repo
+echo "test-repo" >> profiles/repo_name
+cat <<END > profiles/arch.list
+amd64
+arm
+arm64
+x86
+# Prefix keywords
+amd64-linux
+arm-linux
+arm64-linux
+x86-linux
+END
+echo "cat" >> profiles/categories
 cat <<END > profiles/profile/make.defaults
 ARCH="cheese"
 USERLAND="GNU"
@@ -34,16 +45,14 @@ USE_EXPAND_VALUES_ARCH="cheese otherarch"
 IUSE_IMPLICIT="build"
 END
 cat<<END > eclass/test.eclass
-IUSE="eclass-flag"
-
-eclass_func() {
+gen_deps() {
     :
 }
-
 END
 
-mkdir -p "cat/banned-functions"
-cat <<END > cat/banned-functions/banned-functions-7.ebuild || exit 1
+# assert now legal in subshell
+mkdir -p "cat/assert-in-subshell"
+cat <<'END' > cat/assert-in-subshell/assert-in-subshell-7.ebuild
 EAPI="7"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -53,16 +62,25 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-S="\${WORKDIR}"
+S="${WORKDIR}"
 
-src_install() {
-    dohtml -A txt -r foo/.
+pkg_setup() {
+    (
+        test
+    )
+}
+
+test() {
+    (
+        true | false | true
+        assert test
+    )
 }
 END
 
-# negative test for "dolib"
-mkdir -p "cat/banned-functions2"
-cat <<END > cat/banned-functions2/banned-functions2-7.ebuild || exit 1
+# best_version -b, -d, -r for different dependency types
+mkdir -p "cat/best-version"
+cat <<'END' > cat/best-version/best-version-7.ebuild
 EAPI="7"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -72,15 +90,30 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-S="\${WORKDIR}"
+S="${WORKDIR}"
 
-src_install() {
-    dolib libfoo.a foo.o
+pkg_pretend() {
+    for option in -r -b -d; do
+        if ! best_version ${option} cat/pretend-installed >/dev/null ; then
+            die 'failed cat/pretend-installed'
+        fi
+
+        BV1=$(best_version ${option} cat/pretend-installed )
+        [[ "${BV1}" == 'cat/pretend-installed-1' ]] || die "BV1 is ${BV1}"
+
+        if best_version ${option} cat/doesnotexist >/dev/null ; then
+            die 'not failed cat/doesnotexist'
+        fi
+
+        BV2=$(best_version ${option} cat/doesnotexist )
+        [[ "${BV2}" == '' ]] || die "BV2 is ${BV2}"
+    done
 }
 END
 
-mkdir -p "cat/banned-functions3"
-cat <<END > cat/banned-functions3/banned-functions3-7.ebuild || exit 1
+# die now legal in subshell
+mkdir -p "cat/die-in-subshell"
+cat <<'END' > cat/die-in-subshell/die-in-subshell-7.ebuild
 EAPI="7"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -90,7 +123,63 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-S="\${WORKDIR}"
+S="${WORKDIR}"
+
+src_configure() {
+    ( die "boom?" )
+}
+END
+
+#dohtml removed; replacement: dodoc -r, docinto
+mkdir -p "cat/banned-dohtml"
+cat <<'END' > cat/banned-dohtml/banned-dohtml-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_install() {
+    [[ -n "$(declare -F dohtml)" ]] && die "dohtml is banned in ${EAPI}"
+}
+END
+
+#dolib removed; replacement: dolib.a, dolib.so
+mkdir -p "cat/banned-dolib"
+cat <<'END' > cat/banned-dolib/banned-dolib-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_install() {
+    [[ -n "$(declare -F dolib)" ]] && die "dolib is banned in ${EAPI}"
+}
+END
+
+mkdir -p "cat/banned-dolib-rep"
+cat <<'END' > cat/banned-dolib-rep/banned-dolib-rep-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
 
 src_unpack() {
     echo 'libfoo.a' > libfoo.a
@@ -100,28 +189,28 @@ src_unpack() {
 }
 
 src_install() {
-    local ld="\${D%/}/usr/lib"
+    local ld="${D%/}/usr/lib"
     local perms
 
     dolib.a libfoo.a foo.o
 
-    perms=\$(stat -c "%a" "\$ld/libfoo.a")
-    [[ \$perms == "644" ]] || die permission error
-    perms=\$(stat -c "%a" "\$ld/foo.o")
-    [[ \$perms == "644" ]] || die permission error
+    perms="$(stat -c "%a" "${ld}/libfoo.a")"
+    [[ "${perms}" == "644" ]] || die 'permission error'
+    perms="$(stat -c "%a" "${ld}/foo.o")"
+    [[ "${perms}" == "644" ]] || die 'permission error'
 
     dolib.so libfoo.so libfoo.so.1
 
-    perms=\$(stat -c "%a" "\$ld/libfoo.so")
-    [[ \$perms == "755" ]] || die permission error
-    perms=\$(stat -c "%a" "\$ld/libfoo.so.1")
-    [[ \$perms == "755" ]] || die permission error
+    perms="$(stat -c "%a" "${ld}/libfoo.so")"
+    [[ "${perms}" == "755" ]] || die 'permission error'
+    perms="$(stat -c "%a" "${ld}/libfoo.so.1")"
+    [[ "${perms}" == "755" ]] || die 'permission error'
 }
 END
 
-# negative test for "libopts"
-mkdir -p "cat/banned-functions4"
-cat <<END > cat/banned-functions4/banned-functions4-7.ebuild || exit 1
+# domo no longer respects into, always uses /usr
+mkdir -p "cat/changed-domo"
+cat <<'END' > cat/changed-domo/changed-domo-7.ebuild
 EAPI="7"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -131,16 +220,375 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-S="\${WORKDIR}"
+S="${WORKDIR}"
 
 src_install() {
-    libopts "-m0644"
+    touch foo.mo
+    into 'foo'
+    domo foo.mo
+    [[ -d "${D}/foo" ]] && die 'domo used into'
+}
+END
+
+# dostrip new command; controls stripping per file
+mkdir -p "cat/added-dostrip"
+cat <<'END' > cat/added-dostrip/added-dostrip-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_prepare() {
+    [[ -n "$(declare -F dostrip)" ]] || die 'dostrip not defined'
+    echo "int main(){}" > test.cpp
+}
+
+src_compile() {
+    ${CXX:-g++} test.cpp -o test
+}
+
+src_install() {
+    dobin test
+    dostrip -x test || die 'dostrip -x failed'
+}
+
+pkg_postinst() {
+    file "${D}/usr/bin/test" | grep 'not stripped' || die 'dostrip -x has no effect'
+}
+END
+
+# eapply GNU patch 2.7 guaranteed, git patches supported
+mkdir -p "cat/eapply-git-diff-support/files" || exit 1
+cat << 'END' > cat/eapply-git-diff-support/eapply-git-diff-support-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S=${WORKDIR}
+
+src_unpack() {
+    echo first >file || die
+}
+
+src_prepare() {
+    [[ -n "$(declare -F eapply)" ]] || die 'not defined'
+
+    eapply "${FILESDIR}"/first || die 'eapply'
+    [[ "$(< file)" == 'second' ]] || die 'file'
+}
+END
+cat << 'END' > cat/eapply-git-diff-support/files/first
+diff --git a/file b/file
+index 9c59e24..e019be0 100644
+--- a/file
++++ b/file
+@@ -1 +1 @@
+-first
++second
+END
+
+# eapply_user GNU patch 2.7 guaranteed, git patches supported
+mkdir -p "cat/eapply-user-git-diff-support/files" || exit 1
+cat << 'END' > cat/eapply-user-git-diff-support/eapply-user-git-diff-support-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S=${WORKDIR}
+
+src_unpack() {
+    echo "${PALUDIS_USER_PATCHES}"
+    echo first >file || die
+}
+
+src_prepare() {
+    [[ -n "$(declare -F eapply_user)" ]] || die 'not defined'
+
+    eapply_user || die 'eapply_user'
+    cat file
+    [[ "$(< file)" == 'second' ]] || die 'patch failed'
+}
+END
+mkdir -p "../root/var/paludis/user_patches/cat/eapply-user-git-diff-support-7"
+cat << 'END' > ../root/var/paludis/user_patches/cat/eapply-user-git-diff-support-7/eapply-user-git-diff-support-7.patch
+diff --git a/file b/file
+index 9c59e24..e019be0 100644
+--- a/file
++++ b/file
+@@ -1 +1 @@
+-first
++second
+END
+
+# ebegin no longer outputs to stdout
+mkdir -p "cat/ebegin-not-to-stdout"
+cat <<'END' > cat/ebegin-not-to-stdout/ebegin-not-to-stdout-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    ebegin "foo" > stdout 2> stderr
+    [[ -s stdout ]] && die 'ebegin wrote to stdout'
+}
+END
+
+# econf passes --build, --target, --with-sysroot
+mkdir -p "cat/econf-added-options"
+cat <<'END' > cat/econf-added-options/econf-added-options-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+CTARGET="i386-badger-linux-gnu"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_prepare(){
+    cat <<'EOF' > configure
+#!/bin/sh
+
+if echo "$@" | grep -q 'help' ; then
+    echo --build
+    echo --target
+    echo --with-sysroot
+    exit 0
+fi
+
+if ! echo "$@" | grep -q 'build' ; then
+    echo --build missing
+    exit 1
+fi
+
+if ! echo "$@" | grep -q 'target' ; then
+    echo --target missing
+    exit 1
+fi
+
+if ! echo "$@" | grep -q 'with-sysroot' ; then
+    echo --with-sysroot missing
+    exit 1
+fi
+
+exit 0
+EOF
+
+    chmod +x configure
+}
+END
+
+# eend no longer outputs to stdout
+mkdir -p "cat/eend-not-to-stdout"
+cat <<'END' > cat/eend-not-to-stdout/eend-not-to-stdout-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    eend "foo" > stdout 2> stderr
+    [[ -s stdout ]] && die 'eend wrote to stdout'
+}
+END
+
+# einfo no longer outputs to stdout
+mkdir -p "cat/einfo-not-to-stdout"
+cat <<'END' > cat/einfo-not-to-stdout/einfo-not-to-stdout-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    einfo "foo" > stdout 2> stderr
+    [[ -s stdout ]] && die 'einfo wrote to stdout'
+}
+END
+
+# elog no longer outputs to stdout
+mkdir -p "cat/elog-not-to-stdout"
+cat <<'END' > cat/elog-not-to-stdout/elog-not-to-stdout-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    elog "foo" > stdout 2> stderr
+    [[ -s stdout ]] && die 'elog wrote to stdout'
+}
+END
+
+# eqawarn new command; prints QA warning for devs
+mkdir -p "cat/eqawarn-not-to-stdout"
+cat <<'END' > cat/eqawarn-not-to-stdout/eqawarn-not-to-stdout-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    [[ -n "$(declare -F eqawarn)" ]] || die 'eqawarn not defined'
+    eqawarn "foo" > stdout 2> stderr
+    [[ -s stdout ]] && die 'eqawarn wrote to stdout'
+}
+END
+
+# has_version -b, -d, -r for different dependency types
+mkdir -p "cat/has-version"
+cat <<'END' > cat/has-version/has-version-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    for option in -r -b -d; do
+    if ! has_version ${option} cat/pretend-installed ; then
+        die 'failed cat/pretend-installed'
+    fi
+
+    if has_version ${option} cat/doesnotexist >/dev/null ; then
+        die 'not failed cat/doesnotexist'
+    fi
+    done
+}
+END
+
+# libopts removed; replacement: doins w/ get_libdir
+mkdir -p "cat/banned-libopts"
+cat <<'END' > cat/banned-libopts/banned-libopts-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    declare -F libopts
+    [[ -n "$(declare -F libopts)" ]]  && die 'libopts is banned'
+}
+END
+
+# nonfatal implemented both as external helper and function
+mkdir -p "cat/nonfatal-external-and-function"
+cat <<'END' > cat/nonfatal-external-and-function/nonfatal-external-and-function-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+try_other_tests() {
+    emake -j1 check-1
+    emake check-2
+}
+
+src_test_optional() {
+    true
+}
+
+src_test() {
+    # Works in EAPI 4 and newer
+    nonfatal emake check
+    nonfatal try_other_tests
+#     if ! nonfatal emake check; then
+#         eerror 'Tests failed, please attach blah blah blah.'
+#         die 'Tests failed'
+#     fi
+#
+#     # Requires EAPI 7: try_other_tests is a shell function
+#     if ! nonfatal try_other_tests; then
+#         eerror 'Other tests failed, please attach blah blah blah.'
+#         die 'Other tests failed'
+#     fi
+}
+
+src_install() {
+    insinto /usr/share/mytext
+
+    # Works in EAPI 4 and newer
+    if ! nonfatal find -name '*.txt' -exec doins {} +; then
+        die 'Installing text files failed for some reason!'
+    fi
+
+    # Requires EAPI 7: nonfatal called via subprocess
+    if ! find -name '*.txt' -exec nonfatal doins {} +; then
+        die 'Installing text files failed for some reason!'
+    fi
 }
 END
 
 # test for inherit/eclasses still working after ECLASSDIR/ECLASSDIRS removal
-mkdir -p "cat/banned-functions5"
-cat <<END > cat/banned-functions5/banned-functions5-7.ebuild || exit 1
+mkdir -p "cat/removed-eclassdir"
+cat <<'END' > cat/removed-eclassdir/removed-eclassdir-7.ebuild
 EAPI="7"
 inherit test
 
@@ -152,16 +600,15 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-S="\${WORKDIR}"
+S="${WORKDIR}"
 
 src_install() {
-    eclass_func
+    gen_deps
 }
-
 END
 
 mkdir -p "cat/vers"
-cat <<END > cat/vers/vers-7.ebuild || exit 1
+cat <<'END' > cat/vers/vers-7.ebuild || exit 1
 EAPI="7"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -171,40 +618,40 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-S="\${WORKDIR}"
+S="${WORKDIR}"
 
-src_install() {
-    [[ \$(ver_cut 0 1.2.3) == "" ]] || die ver_cut1 failed
-    [[ \$(ver_cut 0-1 1.2.3) == "1" ]] || die ver_cut2 failed
-    [[ \$(ver_cut 1 1.2.3) == "1" ]] || die ver_cut3 failed
-    [[ \$(ver_cut 1- 1.2.3) == "1.2.3" ]] || die ver_cut4 failed
-    [[ \$(ver_cut 1-2 1.2.3) == "1.2" ]] || die ver_cut5 failed
-    [[ \$(ver_cut 1-3 1.2.3) == "1.2.3" ]] || die ver_cut6 failed
-    [[ \$(ver_cut 2 1.2.3) == "2" ]] || die ver_cut7 failed
-    [[ \$(ver_cut 2-3 1.2.3) == "2.3" ]] || die ver_cut8 failed
-    [[ \$(ver_cut 3- 1.2.3) == "3" ]] || die ver_cut9 failed
-    [[ \$(ver_cut 4- 1.2.3) == "" ]] || die ver_cut10 failed
+pkg_pretend() {
+    [[ "$(ver_cut 0 1.2.3)" == "" ]] || die 'ver_cut1 failed'
+    [[ "$(ver_cut 0-1 1.2.3)" == "1" ]] || die 'ver_cut2 failed'
+    [[ "$(ver_cut 1 1.2.3)" == "1" ]] || die 'ver_cut3 failed'
+    [[ "$(ver_cut 1- 1.2.3)" == "1.2.3" ]] || die 'ver_cut4 failed'
+    [[ "$(ver_cut 1-2 1.2.3)" == "1.2" ]] || die 'ver_cut5 failed'
+    [[ "$(ver_cut 1-3 1.2.3)" == "1.2.3" ]] || die 'ver_cut6 failed'
+    [[ "$(ver_cut 2 1.2.3)" == "2" ]] || die 'ver_cut7 failed'
+    [[ "$(ver_cut 2-3 1.2.3)" == "2.3" ]] || die 'ver_cut8 failed'
+    [[ "$(ver_cut 3- 1.2.3)" == "3" ]] || die 'ver_cut9 failed'
+    [[ "$(ver_cut 4- 1.2.3)" == "" ]] || die 'ver_cut10 failed'
 
-    [[ \$(ver_rs 0 \# 1.2.3) == "1.2.3" ]] || die ver_rs1 failed
-    [[ \$(ver_rs 0 \# .11.2.) == "#11.2." ]] || die ver_rs2 failed
-    [[ \$(ver_rs 0-1 \# 1.2.3) == "1#2.3" ]] || die ver_rs3 failed
-    [[ \$(ver_rs 1 \# 1.2.3) == "1#2.3" ]] || die ver_rs4 failed
-    [[ \$(ver_rs 1-2 \# 1.2.3) == "1#2#3" ]] || die ver_rs5 failed
-    [[ \$(ver_rs 2 \# 1.2.3) == "1.2#3" ]] || die ver_rs6 failed
-    [[ \$(ver_rs 2-3 \# 1.2.3) == "1.2#3" ]] || die ver_rs7 failed
-    [[ \$(ver_rs 3 \# 1.2.3) == "1.2.3" ]] || die ver_rs8 failed
+    [[ "$(ver_rs 0 \# 1.2.3)" == "1.2.3" ]] || die 'ver_rs1 failed'
+    [[ "$(ver_rs 0 \# .11.2.)" == "#11.2." ]] || die 'ver_rs2 failed'
+    [[ "$(ver_rs 0-1 \# 1.2.3)" == "1#2.3" ]] || die 'ver_rs3 failed'
+    [[ "$(ver_rs 1 \# 1.2.3)" == "1#2.3" ]] || die 'ver_rs4 failed'
+    [[ "$(ver_rs 1-2 \# 1.2.3)" == "1#2#3" ]] || die 'ver_rs5 failed'
+    [[ "$(ver_rs 2 \# 1.2.3)" == "1.2#3" ]] || die 'ver_rs6 failed'
+    [[ "$(ver_rs 2-3 \# 1.2.3)" == "1.2#3" ]] || die 'ver_rs7 failed'
+    [[ "$(ver_rs 3 \# 1.2.3)" == "1.2.3" ]] || die 'ver_rs8 failed'
 
-    ver_test 1.2 -gt 1.1 || die ver_test1 failed
-    ver_test 1.1.1 -ge 1.1 || die ver_test2 failed
-    ver_test 1.1 -eq 1.1 || die ver_test3 failed
-    ver_test 1.1 -ne 1.2 || die ver_test4 failed
-    ver_test 1.1 -le 1.2 || die ver_test5 failed
-    ver_test 1.0 -lt 1.2 || die ver_test6 failed
+    ver_test 1.2 -gt 1.1 || die 'ver_test1 failed'
+    ver_test 1.1.1 -ge 1.1 || die 'ver_test2 failed'
+    ver_test 1.1 -eq 1.1 || die 'ver_test3 failed'
+    ver_test 1.1 -ne 1.2 || die 'ver_test4 failed'
+    ver_test 1.1 -le 1.2 || die 'ver_test5 failed'
+    ver_test 1.0 -lt 1.2 || die 'ver_test6 failed'
 }
 END
 
 mkdir -p "cat/no-trail-slash"
-cat <<'END' > cat/no-trail-slash/no-trail-slash-7.ebuild || exit 1
+cat <<'END' > cat/no-trail-slash/no-trail-slash-7.ebuild
 EAPI="7"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -217,10 +664,11 @@ KEYWORDS="test"
 S="${WORKDIR}"
 
 test_vars() {
-    [[ $ROOT == "" ]] || die ROOT is non-empty
-    [[ $EROOT == "" ]] || die EROOT is non-empty
-    [[ $D == ${D%/} ]] || die D has trailing slash
-    [[ $ED == ${ED%/} ]] || die ED has trailing slash
+    [[ -z "${ROOT}" ]] || die 'ROOT is non-empty'
+    [[ -z "${EROOT}" ]] || die 'EROOT is non-empty'
+    [[ "${BROOT}" == "${BROOT%/}" ]] || die 'BROOT has trailing slash'
+    [[ "${D}" == "${D%/}" ]] || die 'D has trailing slash'
+    [[ "${ED}" == "${ED%/}" ]] || die 'ED has trailing slash'
 }
 
 pkg_setup() {
@@ -234,8 +682,104 @@ src_install() {
 pkg_postinst() {
     test_vars
 }
-
 END
 
-cd ..
-cd ..
+# eprefix
+mkdir -p "cat/prefix"
+cat <<'END' > cat/prefix/prefix-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+pkg_setup() {
+    die 'FIXME'
+    echo "EPREFIX ${EPREFIX}"
+
+    echo "ED ${ED}"
+    echo "   ${D%/}${EPREFIX}"
+
+    echo "EROOT ${EROOT}"
+    echo "ROOT ${ROOT}"
+    echo "BROOT ${BROOT}"
+    echo "SYSROOT ${SYSROOT}"
+    echo "ESYSROOT ${ESYSROOT}"
+    [[ "${ED}" == "${D%/}${EPREFIX}" ]] || die 'ED is wrong'
+    [[ "${EROOT}" == "${ROOT%/}${EPREFIX}" ]] || die 'EROOT is wrong'
+    [[ "${ESYSROOT}" == "${SYSROOT%/}${EPREFIX}" ]] || die 'ESYSROOT is wrong'
+}
+END
+
+mkdir -p "cat/changed-vars"
+cat <<'END' > cat/changed-vars/changed-vars-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+pkg_setup() {
+    for var in DESTTREE ECLASSDIR INSDESTTREE PORTDIR; do
+        [ -z "${!var+x}" ] || die "${var} has been removed and should not be set"
+    done
+    for var in ENV_UNSET  BDEPEND BROOT ESYSROOT SYSROOT; do
+        [ -z "${!var+x}" ] && die "${var} has been added and should be set"
+    done
+}
+END
+
+mkdir -p "cat/selectors-dep"
+cat <<'END' > cat/selectors-dep/selectors-dep-7.ebuild
+EAPI="7"
+inherit test
+
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+# This will trigger an error if gen_deps outputs empty string
+DEPEND="|| ( $(gen_deps) )"
+END
+
+mkdir -p "cat/selectors-or"
+cat <<END > cat/selectors-or/selectors-or-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="a foo b bar"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+# EAPI 6: this is satisfied w/ USE="-a -b"
+# EAPI 7: requires a+foo OR b+bar
+REQUIRED_USE="|| ( a? ( foo ) b? ( bar ) )"
+END
+
+mkdir -p "cat/selectors-xor"
+cat <<END > cat/selectors-xor/selectors-xor-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="a foo b bar"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+# EAPI 6: this is satisfied w/ USE="-a -b"
+# EAPI 7: requires a+foo XOR b+bar
+REQUIRED_USE="^^ ( a? ( foo ) b? ( bar ) )"
+END

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -392,7 +392,7 @@ KEYWORDS="test"
 
 S="${WORKDIR}"
 
-src_prepare(){
+src_prepare() {
     cat <<'EOF' > configure
 #!/bin/sh
 
@@ -419,7 +419,7 @@ for param in "${@}"; do
         target='1'
     fi
 
-    if [ '--with-sysroot=${ESYSROOT:-/}' = "${param}" ]; then
+    if [ "--with-sysroot=${ESYSROOT:-/}" = "${param}" ]; then
         withsysroot='1'
     fi
 
@@ -444,6 +444,16 @@ exit '1'
 EOF
 
     chmod +x configure
+}
+
+src_configure() {
+    # For some reason, CTARGET is defined as a variable in the current phase,
+    # but not exported to the environment.
+    # For this test to work, we need it available in the configure script, so
+    # just export it.
+    export CTARGET
+
+    default
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -256,12 +256,11 @@ KEYWORDS="test"
 S="${WORKDIR}"
 
 src_prepare() {
-    [[ -n "$(declare -F dostrip)" ]] || die 'dostrip not defined'
     echo "int main(){}" > test.cpp
 }
 
 src_compile() {
-    ${CXX:-g++} test.cpp -o test
+    ${CXX:-g++} -g3 test.cpp -o test
 }
 
 src_install() {

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -522,8 +522,7 @@ KEYWORDS="test"
 S="${WORKDIR}"
 
 pkg_pretend() {
-    [[ -n "$(declare -F eqawarn)" ]] || die 'eqawarn not defined'
-    eqawarn "foo" > stdout 2> stderr
+    eqawarn "foo" > stdout 2> stderr || die 'eqawarn failed, maybe undefined?'
     [[ -s stdout ]] && die 'eqawarn wrote to stdout'
 }
 END

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -237,7 +237,7 @@ src_install() {
     touch foo.mo
     into 'foo'
     domo foo.mo
-    [[ -d "${D}/foo" ]] && die 'domo used into'
+    [[ -f "${D}/usr/share/locale/foo/LC_MESSAGES/${PN}.mo" ]] || die 'domo used into'
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -776,7 +776,6 @@ LICENSE="GPL-2"
 KEYWORDS="test"
 
 pkg_setup() {
-    die 'FIXME'
     echo "EPREFIX ${EPREFIX}"
 
     echo "ED ${ED}"
@@ -787,9 +786,9 @@ pkg_setup() {
     echo "BROOT ${BROOT}"
     echo "SYSROOT ${SYSROOT}"
     echo "ESYSROOT ${ESYSROOT}"
-    [[ "${ED}" == "${D%/}${EPREFIX}" ]] || die 'ED is wrong'
-    [[ "${EROOT}" == "${ROOT%/}${EPREFIX}" ]] || die 'EROOT is wrong'
-    [[ "${ESYSROOT}" == "${SYSROOT%/}${EPREFIX}" ]] || die 'ESYSROOT is wrong'
+    [[ "${ED}" == "${D%/}${EPREFIX}" ]] || die 'ED is wrong ('"'${ED}'"' vs. '"'${D%/}${EPREFIX}'"')'
+    [[ "${EROOT}" == "${ROOT%/}${EPREFIX}" ]] || die 'EROOT is wrong ('"'${EROOT}'"' vs. '"'${ROOT%/}${EPREFIX}'"')'
+    [[ "${ESYSROOT}" == "${SYSROOT%/}${EPREFIX}" ]] || die 'ESYSROOT is wrong ('"'${ESYSROOT}'"' vs. '"'${SYSROOT%/}${EPREFIX}'"')'
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -568,9 +568,13 @@ KEYWORDS="test"
 
 S="${WORKDIR}"
 
-pkg_pretend() {
-    declare -F libopts
-    [[ -n "$(declare -F libopts)" ]]  && die 'libopts is banned'
+src_unpack() {
+    echo 'libfoo.a' > libfoo.a
+}
+
+src_install() {
+    libopts -m0755
+    dolib.a libfoo.a
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -775,7 +775,7 @@ pkg_setup() {
     for var in DESTTREE ECLASSDIR INSDESTTREE PORTDIR; do
         [ -z "${!var+x}" ] || die "${var} has been removed and should not be set"
     done
-    for var in ENV_UNSET  BDEPEND BROOT ESYSROOT SYSROOT; do
+    for var in ENV_UNSET BDEPEND BROOT ESYSROOT SYSROOT; do
         [ -z "${!var+x}" ] && die "${var} has been added and should be set"
     done
 }

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -272,6 +272,37 @@ pkg_postinst() {
     file "${D}/usr/bin/test" | grep 'not stripped' || die 'dostrip -x has no effect'
 }
 END
+mkdir -p "cat/added-dostrip-strip-restrict"
+cat <<'END' > cat/added-dostrip-strip-restrict/added-dostrip-strip-restrict-7.ebuild
+EAPI="7"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+RESTRICT="strip"
+
+S="${WORKDIR}"
+
+src_prepare() {
+    echo "int main(){}" > test.cpp
+}
+
+src_compile() {
+    ${CXX:-g++} -g3 test.cpp -o test
+}
+
+src_install() {
+    dobin test
+    dostrip '/usr/bin/test' || die 'dostrip failed'
+}
+
+pkg_postinst() {
+    file "${D}/usr/bin/test" | grep -v 'not stripped' || die 'dostrip has no effect'
+}
+END
 
 # eapply GNU patch 2.7 guaranteed, git patches supported
 mkdir -p "cat/eapply-git-diff-support/files" || exit 1

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -597,24 +597,11 @@ try_other_tests() {
     emake check-2
 }
 
-src_test_optional() {
-    true
-}
-
 src_test() {
     # Works in EAPI 4 and newer
     nonfatal emake check
+    # Requires EAPI 7: try_other_tests is a shell function
     nonfatal try_other_tests
-#     if ! nonfatal emake check; then
-#         eerror 'Tests failed, please attach blah blah blah.'
-#         die 'Tests failed'
-#     fi
-#
-#     # Requires EAPI 7: try_other_tests is a shell function
-#     if ! nonfatal try_other_tests; then
-#         eerror 'Other tests failed, please attach blah blah blah.'
-#         die 'Other tests failed'
-#     fi
 }
 
 src_install() {

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -169,8 +169,13 @@ KEYWORDS="test"
 
 S="${WORKDIR}"
 
+src_unpack() {
+    echo 'libfoo.a' > libfoo.a
+    echo 'foo.o' > foo.o
+}
+
 src_install() {
-    [[ -n "$(declare -F dolib)" ]] && die "dolib is banned in ${EAPI}"
+    dolib libfoo.a foo.o
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_7_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_7_setup.sh
@@ -144,8 +144,14 @@ KEYWORDS="test"
 
 S="${WORKDIR}"
 
+src_prepare() {
+    mkdir foo
+    touch foo/a.txt
+    touch foo/b.txt
+}
+
 src_install() {
-    [[ -n "$(declare -F dohtml)" ]] && die "dohtml is banned in ${EAPI}"
+    dohtml -A txt -r foo/.
 }
 END
 

--- a/python/package_id_TEST_setup.sh
+++ b/python/package_id_TEST_setup.sh
@@ -55,6 +55,7 @@ virtual/bar foo/bar
 END
 
 cat <<"END" > foo/bar/bar-1.0.ebuild || exit 1
+EAPI="7"
 DESCRIPTION="Test package"
 HOMEPAGE="http://paludis.exherbo.org/"
 SRC_URI="http://example.com/${P}.tar.bz2"
@@ -65,6 +66,7 @@ KEYWORDS="test"
 RESTRICT="monkey"
 DEPEND="foo/bar"
 RDEPEND=""
+BDEPEND="foo/bar"
 PROVIDE="virtual/monkey"
 END
 

--- a/ruby/package_id_TEST.rb
+++ b/ruby/package_id_TEST.rb
@@ -155,9 +155,10 @@ module Paludis
 
         def test_each_metadata
             keys = { "DESCRIPTION" => 1, "INHERITED" => 1, "KEYWORDS" => 1, "EAPI" => 1,
-                "DEPEND" => 1, "LICENSE" => 1,
+                "DEPEND" => 1, "BDEPEND" => 1, "LICENSE" => 1,
                 "RESTRICT" => 1, "SRC_URI" => 1, "HOMEPAGE" => 1, "EBUILD" => 1, "IUSE" => 1,
-                "PALUDIS_CHOICES" => 1, "DEFINED_PHASES" => 1, "SLOT" => 1 }
+                "IUSE_EFFECTIVE" => 1, "PALUDIS_CHOICES" => 1, "DEFINED_PHASES" => 1,
+                "SLOT" => 1 }
             pid_testrepo.each_metadata do | key |
                 assert keys.has_key?(key.raw_name), "no key #{key.raw_name} -> #{key.parse_value}"
                 keys.delete key.raw_name

--- a/ruby/package_id_TEST_setup.sh
+++ b/ruby/package_id_TEST_setup.sh
@@ -66,6 +66,7 @@ foo/bar
 END
 
 cat <<"END" > foo/bar/bar-1.0.ebuild || exit 1
+EAPI="7"
 DESCRIPTION="Test package"
 HOMEPAGE="http://paludis.exherbo.org/"
 SRC_URI="http://example.com/${P}.tar.bz2"
@@ -76,10 +77,12 @@ KEYWORDS="~test"
 RESTRICT="monkey"
 DEPEND="foo/bar"
 RDEPEND=""
+BDEPEND="foo/bar"
 PROVIDE="virtual/monkey"
 END
 
 cat <<"END" > bad/pkg/pkg-1.0.ebuild || exit 1
+EAPI="7"
 DESCRIPTION="Test package"
 HOMEPAGE="http://paludis.exherbo.org/"
 SRC_URI="http://example.com/${P}.tar.bz2"
@@ -90,6 +93,7 @@ KEYWORDS="test!!!"
 RESTRICT="monkey"
 DEPEND="||(foo/bar bar/foo)"
 RDEPEND=""
+BDEPEND="||(foo/bar bar/foo)"
 END
 
 cd ..


### PR DESCRIPTION
This is a HUGE PR, bringing a lot of new tests for `EAPI=7` and updating/fixing already existing ones.

It's a combination of @negril's and mine efforts, backported to the "old" test system that has been traditionally used in paludis. @negril actually wrote it based on something newer, which spawns tests individually in a clean environment and even seems to execute a lot faster, but for getting the `EAPI-7` (and eventually `EAPI=8`) code merged upstream, it's probably better to base it on the system that is being used for older EAPIs and keep the code compatible with C++11 (instead of using later features).

Eventually, after that code is in upstream, I'd like to switch to the "new" system he proposed.

To that effect, code that we need for the "new" system has not been removed, but only commented out.

Regarding the actual changes, these **new** tests were added:
  - `{assert,die}` now supported in subshells
  - new options `-b`, `-d` and `-r` to `{best,has}_version`
  - banned `dolib`, but retaining `dolib.a` and `dolib.so`
  - `domo` not influenced by `into` any longer
  - new `dostrip` utility
  - `eapply{,_user}` now support the `git diff` format
  - `e{begin,end,info,log,qawarn}` may not output to `stdout` any longer
  - `econf` now passes `--build`, `--target` and `--with-sysroot` by default
  - `nonfatal` implemented as both a function and external command
  - correct `${EPREFIX}` usage in `${ED}`, `${EROOT}`, and `${ESYSROOT}`
  - `${DESTTREE}`, `${ECLASSDIR}`, `${INSDESTTREE}` and `${PORTDIR}` removed, `${ENV_UNSET}`, `${BDEPEND}`, `${BROOT}`, `${ESYSROOT}` and `${SYSROOT}` added
  - empty dependency groups no longer satisfy the dependency, which includes `OR` (`||`) and `XOR` (`^^`) clauses
  - `ENV_UNSET` feature.

The following tests were improved/fixed:
  - no trailing slashes on `${D}` and `${ED}`
  - `libopts` fully banned
  - banned `dohtml`
  - `eqawarn` implemented as both a function or external command
  - dead code removal in `nonfatal-as-function-and-external-command`
  - all tests using choice options
  - execute pretend action instead of install action in `vers_*` test so that checking the pretend action actually returns the correct result
  - enable `prefix-7` test, should work now
  - fix python and ruby tests by adding `BDEPDEND` variables to `package_id` tests
  - make sure that ruby code also saves `BDEPEND` and `IUSE_EFFECTIVE` in the metadata for installed packages.

Some tests still fail, but we know why they do: the correct behavior for empty groups is not implemented yet. This will be done at a later time.

All other tests should succeed (other than the tests we disabled and marked with `FIXME`s in the code).

Since this change set is so big, I'll keep it open for longer, so that other people get the change to review it, if they want to. I pondered whether to keep it as one big hunk or split it up into a lot of small PRs, but since all commits are somehow interconnected and they are all just touching test `EAPI=7` code, it wouldn't have made sense to go too fine-grained.