### PR TITLE
EAPI=8: add basic support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ https://github.com/MageSlayer/paludis-gentoo-overlay
     `build_dependencies_key` to `build_dependencies_target_key` (the direct
     equivalent) and may want also to take `build_dependencies_host_key` into
     account.
+
+### EAPI=8 Branch
+
+**Do not use this branch**.
+
+It is **not** feature-complete.
+It **will** break your system if you try to use it in the current state.
+You **will** miss dependencies.
+
+**Do not use this branch.**

--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -1,0 +1,10 @@
+# Configuration for EAPI 8
+# EAPI 8 is specified in PMS.
+
+source ${PALUDIS_EAPIS_DIR}/7.conf
+exported_name = 8
+can_be_pbin = true
+is_pbin = false
+
+ebuild_module_suffixes = 8 7 6 5 4 3 2 1 0
+utility_path_suffixes = 8 7 6 5 4 3 2 1 0

--- a/paludis/repositories/e/eapis/CMakeLists.txt
+++ b/paludis/repositories/e/eapis/CMakeLists.txt
@@ -8,6 +8,7 @@ install(FILES
           "${CMAKE_CURRENT_SOURCE_DIR}/5.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/6.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/7.conf"
+          "${CMAKE_CURRENT_SOURCE_DIR}/8.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/exheres-0.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/paludis-1.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+0.conf"
@@ -18,6 +19,7 @@ install(FILES
           "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+5.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+6.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+7.conf"
+          "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+8.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+exheres-0.conf"
           "${CMAKE_CURRENT_SOURCE_DIR}/pbin-1+paludis-1.conf"
         DESTINATION

--- a/paludis/repositories/e/eapis/pbin-1+8.conf
+++ b/paludis/repositories/e/eapis/pbin-1+8.conf
@@ -1,0 +1,6 @@
+# Configuration for EAPI 8, used by Paludis binary format 1.
+# EAPI 8 is specified in PMS.
+
+source ${PALUDIS_EAPIS_DIR}/8.conf
+can_be_pbin = false
+is_pbin = true


### PR DESCRIPTION
This PR merely adds basic definitions for `EAPI=8`.

Actual changes provided through subsequent PRs.