### PR TITLE
EAPI=8: ban hasq, hasv and useq.

### DIFF
--- a/paludis/repositories/e/ebuild/utils/8/CMakeLists.txt
+++ b/paludis/repositories/e/ebuild/utils/8/CMakeLists.txt
@@ -1,0 +1,16 @@
+foreach(bannedscript
+          hasq
+          hasv
+          useq)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/banned_in_eapi_8"
+                 "${CMAKE_CURRENT_BINARY_DIR}/${bannedscript}"
+                 @ONLY)
+endforeach()
+
+install(PROGRAMS
+          "${CMAKE_CURRENT_BINARY_DIR}/hasq"
+          "${CMAKE_CURRENT_BINARY_DIR}/hasv"
+          "${CMAKE_CURRENT_BINARY_DIR}/useq"
+          "${CMAKE_CURRENT_SOURCE_DIR}/banned_in_eapi_8"
+        DESTINATION
+          "${CMAKE_INSTALL_FULL_LIBEXECDIR}/paludis/utils/8")

--- a/paludis/repositories/e/ebuild/utils/8/banned_in_eapi_8
+++ b/paludis/repositories/e/ebuild/utils/8/banned_in_eapi_8
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# vim: set sw=4 sts=4 et :
+
+# Copyright (c) 2018 Denis Golovan
+# Copyright (c) 2021 Mihai Moldovan
+#
+# This file is part of the Paludis package manager. Paludis is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation; either version
+# 2 of the License, or (at your option) any later version.
+#
+# Paludis is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+COLOUR_RED=$'\e[31;01m'
+COLOUR_NORMAL=$'\e[0m'
+
+echo "${COLOUR_RED}!!! Ebuild bug: '$(basename ${0} )' banned in EAPI 8${COLOUR_NORMAL}"
+echo "$(basename ${0} ): making ebuild PID ${EBUILD_KILL_PID} exit with error" 1>&2
+kill -s SIGUSR1 "${EBUILD_KILL_PID}"
+
+exit 123


### PR DESCRIPTION
This PR bans the functions `hasq`, `hasv` and `useq` for `EAPI=8`.

The replacements are simply `has` and `use`.

Merging without a merge commit.