### PR TITLE
EAPI=8: add --datarootdir as default econf parameter.

### DIFF
--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -8,3 +8,5 @@ is_pbin = false
 
 ebuild_module_suffixes = 8 7 6 5 4 3 2 1 0
 utility_path_suffixes = 8 7 6 5 4 3 2 1 0
+
+econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --datarootdir::--datarootdir=\${EPREFIX}/usr/share


### PR DESCRIPTION
`EAPI=8` now passes `--datarootdir` by default via `econf`.

Merging without a merge commit.