### PR TITLE
EAPI=8: add --disable-static as default econf parameter.

### DIFF
--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -9,4 +9,4 @@ is_pbin = false
 ebuild_module_suffixes = 8 7 6 5 4 3 2 1 0
 utility_path_suffixes = 8 7 6 5 4 3 2 1 0
 
-econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --datarootdir::--datarootdir=\${EPREFIX}/usr/share
+econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --datarootdir::--datarootdir=\${EPREFIX}/usr/share --disable-static::--disable-static


### PR DESCRIPTION
`EAPI=8` now passes `--disable-static` by default via `econf`.

Merging without a merge commit.