### PR TITLE
EAPI=8: implement -r (relative) option to dosym.

### DIFF
--- a/paludis/repositories/e/eapi.cc
+++ b/paludis/repositories/e/eapi.cc
@@ -260,6 +260,7 @@ namespace
                         n::doman_lang_filenames_overrides() = destringify_key<bool>(k, "doman_lang_filenames_overrides"),
                         n::domo_respects_into() = destringify_key<bool>(k, "domo_respects_into"),
                         n::dosym_mkdir() = destringify_key<bool>(k, "dosym_mkdir"),
+                        n::dosym_r() = destringify_key<bool>(k, "dosym_r"),
                         n::econf_extra_options() = k.get("econf_extra_options"),
                         n::econf_extra_options_help_dependent() = k.get("econf_extra_options_help_dependent"),
                         n::exeopts_influences_doinitd() = destringify_key<bool>(k, "exeopts_influences_doinitd"),

--- a/paludis/repositories/e/eapi.hh
+++ b/paludis/repositories/e/eapi.hh
@@ -73,6 +73,7 @@ namespace paludis
         typedef Name<struct name_doman_lang_filenames_overrides> doman_lang_filenames_overrides;
         typedef Name<struct name_domo_respects_into> domo_respects_into;
         typedef Name<struct name_dosym_mkdir> dosym_mkdir;
+        typedef Name<struct name_dosym_r> dosym_r;
         typedef Name<struct name_eapi> eapi;
         typedef Name<struct name_ebuild_bad_options> ebuild_bad_options;
         typedef Name<struct name_ebuild_config> ebuild_config;
@@ -516,6 +517,7 @@ namespace paludis
             NamedValue<n::doman_lang_filenames_overrides, bool> doman_lang_filenames_overrides;
             NamedValue<n::domo_respects_into, bool> domo_respects_into;
             NamedValue<n::dosym_mkdir, bool> dosym_mkdir;
+            NamedValue<n::dosym_r, bool> dosym_r;
             NamedValue<n::econf_extra_options, std::string> econf_extra_options;
             NamedValue<n::econf_extra_options_help_dependent, std::string> econf_extra_options_help_dependent;
             NamedValue<n::exeopts_influences_doinitd, bool> exeopts_influences_doinitd;

--- a/paludis/repositories/e/eapis/0.conf
+++ b/paludis/repositories/e/eapis/0.conf
@@ -301,6 +301,7 @@ has_subslots = false
 
 unpack_suffixes = tar tar.gz,tgz,tar.Z tar.bz2,tbz2,tbz zip,ZIP,jar gz,Z,z bz2 rar,RAR lha,LHa,LHA,lzh a,deb tar.lzma lzma 7z,7Z
 
+dosym_r = false
 exeopts_influences_doinitd = true
 insopts_influences_doconfd = true
 insopts_influences_doenvd = true

--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -11,6 +11,7 @@ utility_path_suffixes = 8 7 6 5 4 3 2 1 0
 
 econf_extra_options_help_dependent = ${econf_extra_options_help_dependent} --datarootdir::--datarootdir=\${EPREFIX}/usr/share --disable-static::--disable-static
 
+dosym_r = true
 exeopts_influences_doinitd = false
 insopts_influences_doconfd = false
 insopts_influences_doenvd = false

--- a/paludis/repositories/e/eapis/exheres-0.conf
+++ b/paludis/repositories/e/eapis/exheres-0.conf
@@ -403,6 +403,7 @@ annotations_myoptions_number_selected_exactly_one = exactly-one
 annotations_suggesions_group_name = group-name
 annotations_system_implicit = implicit
 
+dosym_r = false
 exeopts_influences_doinitd = true
 insopts_influences_doconfd = true
 insopts_influences_doenvd = true

--- a/paludis/repositories/e/eapis/paludis-1.conf
+++ b/paludis/repositories/e/eapis/paludis-1.conf
@@ -298,6 +298,7 @@ new_stdin = false
 
 unpack_suffixes = tar tar.gz,tgz,tar.Z tar.bz2,tbz2,tbz zip,ZIP,jar gz,Z,z bz2 rar,RAR lha,LHa,LHA,lzh a,deb tar.lzma lzma 7z,7Z tar.xz,txz xz
 
+dosym_r = false
 exeopts_influences_doinitd = true
 insopts_influences_doconfd = true
 insopts_influences_doenvd = true

--- a/paludis/repositories/e/ebuild.cc
+++ b/paludis/repositories/e/ebuild.cc
@@ -265,6 +265,7 @@ EbuildCommand::operator() ()
                 tools->insopts_influences_doheader() ? "yes" : "")
         .setenv("PALUDIS_EXEOPTS_INFLUENCES_DOINITD",
                 tools->exeopts_influences_doinitd() ? "yes" : "")
+        .setenv("PALUDIS_DOSYM_R", tools->dosym_r() ? "yes" : "")
         .setenv("PALUDIS_FAILURE_IS_FATAL", tools->failure_is_fatal() ? "yes" : "")
         .setenv("PALUDIS_LOG_TO_STDOUT", tools->log_to_stdout() ? "yes" : "")
         .setenv("PALUDIS_DOMO_RESPECTS_INTO", tools->domo_respects_into() ? "yes" : "")

--- a/paludis/repositories/e/ebuild/utils/dosym
+++ b/paludis/repositories/e/ebuild/utils/dosym
@@ -2,6 +2,7 @@
 # vim: set sw=4 sts=4 et :
 
 # Copyright (c) 2006 Stephen Bennett
+# Copyright (c) 2021 Mihai Moldovan
 #
 # Based in part upon dosym from Portage, which is Copyright 1995-2005
 # Gentoo Foundation and distributed under the terms of the GNU General
@@ -25,21 +26,171 @@ source ${PALUDIS_EBUILD_DIR}/die_functions.bash
 source ${PALUDIS_EBUILD_DIR}/pipe_functions.bash
 source ${PALUDIS_EBUILD_DIR}/output_functions.bash
 
+# Canonicalizes a path, without the need of any component to actually exist.
+# This essentially means:
+#   - multiple consecutive slashes are dropped
+#   - references to the current directory (".") are dropped
+#   - references to the parent directory (".." are dropped and handled by
+#     removing the appropriate amount of components.
+canonical_path() {
+    typeset path="${1}"
+    typeset ret=''
+    typeset -i absolute='0'
+
+    # Check if we're working with a relative or an absolute path.
+    if [[ "${path}" != "${path#/}" ]]; then
+        absolute='1'
+    fi
+
+    # Move through components.
+    typeset -i up_level='0'
+    typeset cur_component=''
+    typeset tmp=''
+    while [[ '.' != "${path}" ]] && [[ '/' != "${path}" ]]; do
+        cur_component="$(basename "${path}")"
+
+        # Skip references to the current directory.
+        if [[ '.' != "${cur_component}" ]]; then
+            if [[ '..' = "${cur_component}" ]]; then
+                # If the current component is a reference to the parent
+                # directory, record that and do nothing else.
+                ((++up_level))
+            else
+                # Otherwise, it's a component we may need to process.
+                if [[ '0' -ne "${up_level}" ]]; then
+                    # We have to skip levels, so ignore the component and
+                    # decrement the skipping counter.
+                    ((--up_level))
+                else
+                    # Okay, we shall handle the component. Prepend it to our
+                    # return value.
+                    # For good measure, leave don't append a slash for the
+                    # last component.
+                    tmp="${ret}"
+                    ret="${cur_component}"
+                    if [[ -n "${tmp}" ]]; then
+                        ret="${ret}/${tmp}"
+                    fi
+                fi
+            fi
+        fi
+
+        # Drop the component and re-enter loop.
+        path="$(dirname "${path}")"
+    done
+
+    if [[ '1' -eq "${absolute}" ]]; then
+        # Lastly, prepend a slash for absolute paths.
+        ret="/${ret}"
+    else
+        # For relative paths, prepend the remaining up levels.
+        while [[ '0' -ne "${up_level}" ]]; do
+            tmp="${ret}"
+            ret=".."
+            if [[ -n "${tmp}" ]]; then
+                ret="${ret}/${tmp}"
+            fi
+
+            ((--up_level))
+        done
+
+        if [[ -z "${ret}" ]]; then
+            # Make sure that the "return value" is not empty.
+            # Note that this is trivially true for absolute paths.
+            ret='.'
+        fi
+    fi
+
+    printf '%s\n' "${ret}"
+}
+
 if [[ ! -d ${!PALUDIS_IMAGE_DIR_VAR%/}/ ]]; then
     paludis_die_or_error "\${${PALUDIS_IMAGE_DIR_VAR}} not valid; aborting"
+fi
+
+typeset relative='false'
+
+if [[ -n "${PALUDIS_DOSYM_R}" ]] ; then
+    if [[ "${1}" == '-r' ]] ; then
+        shift
+        relative='true'
+    fi
 fi
 
 if [[ ${#} -ne 2 ]]; then
     paludis_die_or_error "exactly two arguments needed."
 fi
 
-if [[ ! -d $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}") ]]; then
+typeset from="${1}"
+typeset to="${2}"
+
+if [[ 'true' = "${relative}" ]]; then
+    # Relative mode only supports absolute paths.
+    if [[ "${from#/}" = "${from}" ]]; then
+        paludis_die_or_error "relative mode only works with absolute paths, but given path was relative: ${from}"
+    fi
+
+    from="$(canonical_path "${from}")"
+fi
+
+if [[ ! -d $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${to#/}") ]]; then
     if [[ -n "${PALUDIS_DOSYM_NO_MKDIR}" ]] ; then
-        die "error: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}" ) does not exist"
+        die "error: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${to#/}" ) does not exist"
     else
-        ebuild_notice "qa" "$0: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}") does not exist; creating. Please fix the ebuild to create it explicitly."
-        dodir $(dirname $2)
+        ebuild_notice "qa" "$0: target directory $(dirname "${!PALUDIS_IMAGE_DIR_VAR%/}/${to#/}") does not exist; creating. Please fix the ebuild to create it explicitly."
+        dodir "$(dirname "${to}")"
     fi
 fi
 
-ln -snf "${1}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/}" || paludis_die_or_error "creation of symlink ${!PALUDIS_IMAGE_DIR_VAR%/}/${2#/} failed"
+if [[ 'true' = "${relative}" ]]; then
+    # Make sure that the to location is an absolute path and drop the last
+    # component, which must be a file name.
+    typeset to_full="$(dirname "$(canonical_path "/${to#/}")")"
+
+    # Find longest matching prefix.
+    typeset to_work="${to_full}"
+    typeset from_work="${from}"
+    typeset to_comp=''
+    typeset from_comp=''
+    while [[ "${to_comp}" = "${from_comp}" ]]; do
+        # Drop current component - we know that it matches.
+        to_work="${to_work#*/}"
+        from_work="${from_work#*/}"
+
+        # Extract new components.
+        to_comp="${to_work%%/*}"
+        from_comp="${from_work%%/*}"
+    done
+
+    # Now that we removed the longest matching prefix, we only have to
+    # "convert" the remaining directory components in the "to" working
+    # path to dir up references.
+    while [[ -n "${to_comp}" ]]; do
+        # Add new up level.
+        from_work="../${from_work}"
+
+        # Drop current component.
+        typeset to_work_new="${to_work#*/}"
+
+        # If nothing was dropped, it means that we can drop all, since it's
+        # already a single component.
+        if [[ "${to_work}" = "${to_work_new}" ]]; then
+            to_work=''
+        else
+            to_work="${to_work_new}"
+        fi
+
+        # Extract new component.
+        to_comp="${to_work%%/*}"
+    done
+
+    # Finally, make sure that the modified path is not empty.
+    if [[ -z "${from_work}" ]]; then
+        from_work='.'
+    fi
+
+    # The modified path will be our new from value.
+    from="${from_work}"
+fi
+
+ln -snf "${from}" "${!PALUDIS_IMAGE_DIR_VAR%/}/${to#/}" || paludis_die_or_error "creation of symlink ${!PALUDIS_IMAGE_DIR_VAR%/}/${to#/} failed"


### PR DESCRIPTION
The `dosym` utility now supports an optional parameter to automatically convert a symlink into a relative representation, which is very useful for symlinks within chroots and other scenarios.

PMS specifies that the algorithm should return a path equivalent to the following shell function (using tools from GNU coreutils 8.32):

```
dosym_relative_path() {
  local link=$(realpath -m -s "/${2#/}")
  local linkdir=$(dirname "${link}")
  realpath -m -s --relative-to="${linkdir}" "$1"
}
```

Merging without a merge commit.