### PR TITLE
EAPI=8: drop 7Zip, LHA and RAR archive support.

### DIFF
--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -18,3 +18,7 @@ insopts_influences_doenvd = false
 insopts_influences_doheader = false
 
 bash_compat = 5.0
+
+# Dropped rar,RAR lha,LHa,LHA,lzh 7z,7Z.
+# Added none.
+unpack_suffixes = tar tar.gz,tgz,tar.Z tar.bz2,tbz2,tbz zip,ZIP,jar gz,Z,z bz2 a,deb tar.lzma lzma tar.xz xz tar.xz,txz


### PR DESCRIPTION
More exotic archives like these should use the `unpacker` eclass.

Merging without a merge commit.