### PR TITLE
EAPI=8: make the PROPERTIES and RESTRICT variables source-merged.

### DIFF
--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -22,3 +22,5 @@ bash_compat = 5.0
 # Dropped rar,RAR lha,LHa,LHA,lzh 7z,7Z.
 # Added none.
 unpack_suffixes = tar tar.gz,tgz,tar.Z tar.bz2,tbz2,tbz zip,ZIP,jar gz,Z,z bz2 a,deb tar.lzma lzma tar.xz xz tar.xz,txz
+
+source_merged_variables = ${source_merged_variables} PROPERTIES RESTRICT


### PR DESCRIPTION
This means that ebuilds will append to them by default.

Merging without a merge commit.