### PR TITLE
EAPI=8: implement fetch and mirror overrides.

### DIFF
--- a/paludis/repositories/e/eapi.cc
+++ b/paludis/repositories/e/eapi.cc
@@ -200,6 +200,8 @@ namespace
                         n::restrict_fetch() = make_set(check_get(k, "restrict_fetch")),
                         n::restrict_mirror() = make_set(check_get(k, "restrict_mirror")),
                         n::restrict_primaryuri() = make_set(check_get(k, "restrict_primaryuri")),
+                        n::restrict_fetch_override() = make_set(check_get(k, "restrict_fetch_override")),
+                        n::restrict_mirror_override() = make_set(check_get(k, "restrict_mirror_override")),
                         n::save_base_variables() = check_get(k, "save_base_variables"),
                         n::save_unmodifiable_variables() = check_get(k, "save_unmodifiable_variables"),
                         n::save_variables() = check_get(k, "save_variables"),

--- a/paludis/repositories/e/eapi.hh
+++ b/paludis/repositories/e/eapi.hh
@@ -204,6 +204,8 @@ namespace paludis
         typedef Name<struct name_restrict_fetch> restrict_fetch;
         typedef Name<struct name_restrict_mirror> restrict_mirror;
         typedef Name<struct name_restrict_primaryuri> restrict_primaryuri;
+        typedef Name<struct name_restrict_fetch_override> restrict_fetch_override;
+        typedef Name<struct name_restrict_mirror_override> restrict_mirror_override;
         typedef Name<struct name_restrictions> restrictions;
         typedef Name<struct name_run_depend> run_depend;
         typedef Name<struct name_save_base_variables> save_base_variables;
@@ -471,6 +473,8 @@ namespace paludis
             NamedValue<n::restrict_fetch, std::shared_ptr<Set<std::string> > > restrict_fetch;
             NamedValue<n::restrict_mirror, std::shared_ptr<Set<std::string> > > restrict_mirror;
             NamedValue<n::restrict_primaryuri, std::shared_ptr<Set<std::string> > > restrict_primaryuri;
+            NamedValue<n::restrict_fetch_override, std::shared_ptr<Set<std::string> > > restrict_fetch_override;
+            NamedValue<n::restrict_mirror_override, std::shared_ptr<Set<std::string> > > restrict_mirror_override;
             NamedValue<n::save_base_variables, std::string> save_base_variables;
             NamedValue<n::save_unmodifiable_variables, std::string> save_unmodifiable_variables;
             NamedValue<n::save_variables, std::string> save_variables;

--- a/paludis/repositories/e/eapis/0.conf
+++ b/paludis/repositories/e/eapis/0.conf
@@ -273,6 +273,8 @@ uri_labels = \
 restrict_mirror = mirror nomirror
 restrict_fetch = fetch nofetch
 restrict_primaryuri = primaryuri
+restrict_fetch_override =
+restrict_mirror_override =
 
 pipe_commands_no_slot_or_repo = true
 

--- a/paludis/repositories/e/eapis/8.conf
+++ b/paludis/repositories/e/eapis/8.conf
@@ -25,3 +25,6 @@ bash_compat = 5.0
 unpack_suffixes = tar tar.gz,tgz,tar.Z tar.bz2,tbz2,tbz zip,ZIP,jar gz,Z,z bz2 a,deb tar.lzma lzma tar.xz xz tar.xz,txz
 
 source_merged_variables = ${source_merged_variables} PROPERTIES RESTRICT
+
+restrict_fetch_override = fetch+
+restrict_mirror_override = mirror+

--- a/paludis/repositories/e/eapis/exheres-0.conf
+++ b/paludis/repositories/e/eapis/exheres-0.conf
@@ -351,6 +351,8 @@ dependency_labels = \
 restrict_mirror = mirror
 restrict_fetch = fetch
 restrict_primaryuri =
+restrict_fetch_override =
+restrict_mirror_override =
 
 pipe_commands_no_slot_or_repo = false
 

--- a/paludis/repositories/e/eapis/paludis-1.conf
+++ b/paludis/repositories/e/eapis/paludis-1.conf
@@ -272,6 +272,8 @@ dependency_labels = \
 restrict_mirror = mirror
 restrict_fetch = fetch
 restrict_primaryuri =
+restrict_fetch_override =
+restrict_mirror_override =
 
 pipe_commands_no_slot_or_repo = true
 

--- a/paludis/repositories/e/fetch_visitor.cc
+++ b/paludis/repositories/e/fetch_visitor.cc
@@ -158,7 +158,7 @@ FetchVisitor::visit(const FetchableURISpecTree::NodeType<FetchableURIDepSpec>::T
         throw ActionFailedError("No fetch action label available");
 
     auto repo(_imp->env->fetch_repository(_imp->id->repository_name()));
-    SourceURIFinder source_uri_finder(_imp->env, repo.get(),
+    SourceURIFinder source_uri_finder(_imp->env, repo.get(), _imp->eapi,
             node.spec()->original_url(), node.spec()->filename(), _imp->mirrors_name, _imp->get_mirrors_fn);
     (*_imp->labels.begin())->accept(source_uri_finder);
     for (const auto & uri_to_filename : source_uri_finder)

--- a/paludis/repositories/e/source_uri_finder.hh
+++ b/paludis/repositories/e/source_uri_finder.hh
@@ -26,6 +26,7 @@
 #include <paludis/dep_label.hh>
 #include <paludis/environment-fwd.hh>
 #include <paludis/repository-fwd.hh>
+#include <paludis/repositories/e/eapi-fwd.hh>
 #include <functional>
 
 namespace paludis
@@ -46,6 +47,7 @@ namespace paludis
             public:
                 SourceURIFinder(const Environment * const env,
                         const Repository * const repo,
+                        const EAPI & eapi,
                         const std::string & url,
                         const std::string & filename,
                         const std::string & mirrors_name,

--- a/paludis/repositories/e/source_uri_finder_TEST.cc
+++ b/paludis/repositories/e/source_uri_finder_TEST.cc
@@ -18,6 +18,7 @@
  */
 
 #include <paludis/repositories/e/source_uri_finder.hh>
+#include <paludis/repositories/e/eapi.hh>
 
 #include <paludis/environments/test/test_environment.hh>
 
@@ -54,8 +55,9 @@ TEST(SourceURIFinder, Works)
                     n::name() = RepositoryName("repo")
                     )));
     env.add_repository(1, repo);
+    const std::shared_ptr<const EAPI> eapi(EAPIData::get_instance()->eapi_from_string("paludis-1"));
 
-    SourceURIFinder f(&env, repo.get(), "http://example.com/path/input", "output", "monkey",
+    SourceURIFinder f(&env, repo.get(), *eapi, "http://example.com/path/input", "output", "monkey",
             get_mirrors_fn);
     URIMirrorsThenListedLabel label("mirrors-then-listed");
     label.accept(f);
@@ -79,8 +81,9 @@ TEST(SourceURIFinder, Mirrors)
                     n::name() = RepositoryName("repo")
                     )));
     env.add_repository(1, repo);
+    const std::shared_ptr<const EAPI> eapi(EAPIData::get_instance()->eapi_from_string("paludis-1"));
 
-    SourceURIFinder f(&env, repo.get(), "mirror://example/path/input", "output", "repo", get_mirrors_fn);
+    SourceURIFinder f(&env, repo.get(), *eapi, "mirror://example/path/input", "output", "repo", get_mirrors_fn);
     URIMirrorsThenListedLabel label("mirrors-then-listed");
     label.accept(f);
 


### PR DESCRIPTION
In `EAPI=8`, each URI can be prefixed with specific strings to override mirror or fetch restrictions.

Handle that by checking if URIs start with an override string in the label handling function adding mirrors.

This isn't very elegant, but works. However, it would be better to add support for this in the depspec parsing code, add new URI override types (as... non-leaf nodes, maybe?) and modify the labels accordingly if overrides has been found, but that would be way more complicated.

Merging without a merge commit.