### PR TITLE
repositories: bump flat_list minimum size to 22.

### DIFF
--- a/paludis/repositories/e/eapis/0.conf
+++ b/paludis/repositories/e/eapis/0.conf
@@ -200,7 +200,7 @@ metadata_use_expand_hidden = USE_EXPAND_HIDDEN
 metadata_defined_phases = DEFINED_PHASES
 metadata_scm_revision =
 
-flat_list_minimum_size = 17
+flat_list_minimum_size = 22
 flat_list_build_depend = 0
 flat_list_short_description = 7
 flat_list_long_description = -1

--- a/paludis/repositories/e/ebuild_flat_metadata_cache_TEST_setup.sh
+++ b/paludis/repositories/e/ebuild_flat_metadata_cache_TEST_setup.sh
@@ -54,6 +54,11 @@ the/pdepend
 0
 the-properties
 
+
+
+
+
+
 END
 
 mkdir cat/flat_list-stale
@@ -84,6 +89,11 @@ the/pdepend
 
 0
 the-properties
+
+
+
+
+
 
 END
 TZ=UTC touch -t 199901010101 metadata/cache/cat/flat_list-stale-1 || exit 2
@@ -117,6 +127,11 @@ the/pdepend
 0
 the-properties
 
+
+
+
+
+
 END
 
 mkdir cat/flat_list-eclass
@@ -139,6 +154,11 @@ the/pdepend
 
 0
 the-properties
+
+
+
+
+
 
 END
 
@@ -170,6 +190,11 @@ the/pdepend
 
 0
 the-properties
+
+
+
+
+
 
 END
 TZ=UTC touch -t 197001010001 cat/flat_list-eclass-stale/flat_list-eclass-stale-1.ebuild || exit 2
@@ -204,6 +229,11 @@ the/pdepend
 0
 the-properties
 
+
+
+
+
+
 END
 
 mkdir cat/flat_list-eclass-gone
@@ -235,6 +265,11 @@ the/pdepend
 0
 the-properties
 
+
+
+
+
+
 END
 
 mkdir cat/flat_list-detection
@@ -257,6 +292,11 @@ the/pdepend
 
 0
 the-properties
+
+
+
+
+
 
 END
 


### PR DESCRIPTION
PMS currently mandates that the `flat_list` cache file format can have up to 22 entries, potentially more.

Sync the code up with the specification.

Note that the `flat_list` format is essentially dead, unused and we shouldn't spend too much time on improving this feature.

Merging without a merge commit.