### PR TITLE
EAPI=8: support PROPERTIES='test_network'.

### DIFF
--- a/paludis/repositories/e/do_install_action.cc
+++ b/paludis/repositories/e/do_install_action.cc
@@ -139,9 +139,12 @@ paludis::erepository::do_install_action(
     bool test_restrict;
     bool strip_restrict;
     {
-        DepSpecFlattener<PlainTextSpecTree, PlainTextDepSpec> restricts(env, id);
+        DepSpecFlattener<PlainTextSpecTree, PlainTextDepSpec> restricts(env, id),
+                                                              properties(env, id);
         if (id->restrict_key())
             id->restrict_key()->parse_value()->top()->accept(restricts);
+        if (id->properties_key())
+            id->properties_key()->parse_value()->top()->accept(properties);
 
         userpriv_restrict =
             indirect_iterator(restricts.end()) != std::find_if(indirect_iterator(restricts.begin()), indirect_iterator(restricts.end()),
@@ -150,8 +153,10 @@ paludis::erepository::do_install_action(
                     std::bind(std::equal_to<>(), std::bind(std::mem_fn(&StringDepSpec::text), _1), "nouserpriv"));
 
         test_restrict =
-            indirect_iterator(restricts.end()) != std::find_if(indirect_iterator(restricts.begin()), indirect_iterator(restricts.end()),
-                    std::bind(std::equal_to<>(), std::bind(std::mem_fn(&StringDepSpec::text), _1), "test"));
+            (indirect_iterator(restricts.end()) != std::find_if(indirect_iterator(restricts.begin()), indirect_iterator(restricts.end()),
+                    std::bind(std::equal_to<>(), std::bind(std::mem_fn(&StringDepSpec::text), _1), "test"))) &&
+            (!(indirect_iterator(properties.end()) != std::find_if(indirect_iterator(properties.begin()), indirect_iterator(properties.end()),
+                    std::bind(std::equal_to<>(), std::bind(std::mem_fn(&StringDepSpec::text), _1), "test_network"))));
 
         strip_restrict =
             indirect_iterator(restricts.end()) != std::find_if(indirect_iterator(restricts.begin()), indirect_iterator(restricts.end()),

--- a/paludis/repositories/e/ebuild/ebuild.bash
+++ b/paludis/repositories/e/ebuild/ebuild.bash
@@ -624,6 +624,23 @@ paludis_phase_to_function_name() {
     die "Usage error: Unknown phase '${1}'"
 }
 
+check_word_in_string() {
+    local word="${1}"
+    local string="${2}"
+    local ret='1'
+
+    [[ -z "${word}" ]] && die 'Usage error: illogical to search for empty word in a string'
+
+    if [[ -n "${string}" ]]; then
+        case "${string}" in
+            ("${word} "*|*" ${word}"|*" ${word} "*|"${word}")
+                ret='0'
+        esac
+    fi
+
+    return "${ret}"
+}
+
 ebuild_main()
 {
     if ! [[ -e /proc/self ]] && [[ "$(uname -s)" == Linux ]] ; then
@@ -693,8 +710,10 @@ ebuild_main()
 
         # Restrict network access if running under sandbox
         if [[ $action != unpack ]] && [[ $action != fetch_extra ]] ; then
-            if esandbox check 2>/dev/null; then
-                esandbox enable_net || ebuild_notice "warning" "esandbox enable_net returned failure"
+            if [[ 'test' != "${action}" ]] || ! check_word_in_string 'test_network' "${PROPERTIES}"; then
+                if esandbox check 2>/dev/null; then
+                    esandbox enable_net || ebuild_notice "warning" "esandbox enable_net returned failure"
+                fi
             fi
         fi
 
@@ -702,8 +721,10 @@ ebuild_main()
         local paludis_ebuild_phase_status="${?}"
 
         if [[ $action != unpack ]] && [[ $action != fetch_extra ]] ; then
-            if esandbox check 2>/dev/null; then
-                esandbox disable_net || ebuild_notice "warning" "esandbox disable_net returned failure"
+            if [[ 'test' != "${action}" ]] || ! check_word_in_string 'test_network' "${PROPERTIES}"; then
+                if esandbox check 2>/dev/null; then
+                    esandbox disable_net || ebuild_notice "warning" "esandbox disable_net returned failure"
+                fi
             fi
         fi
 


### PR DESCRIPTION
According to `PMS`, this is an optionally supported value and, if set, overrides a setting of `RESTRICT='test'`, i.e., enables running tests.

This sounds a bit convoluted, and it is, but gets clear with the rationale behind this property: it is mostly meant as an annotation to denote that the tests require a network connection to execute and that, if networking is not available, they will fail. They are, however, supposed to pass with networking available. To that effect, ebuilds often disable tests via the `RESTRICT` feature.

With `test_network` in the `PROPERTIES` variable, we can re-enable them and, additionally, make sure to disable the network sandbox.

Merging without a merge commit.