### PR TITLE
EAPI=8: add tests.

### DIFF
--- a/paludis/repositories/e/CMakeLists.txt
+++ b/paludis/repositories/e/CMakeLists.txt
@@ -122,6 +122,7 @@ foreach(test
           e_repository_TEST_5
           e_repository_TEST_6
           e_repository_TEST_7
+          e_repository_TEST_8
           e_repository_TEST_ever
           e_repository_TEST_exheres_0
           e_repository_TEST_exlibs

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -182,11 +182,29 @@ TEST(ERepository, InstallEAPI8)
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/fetch-restrictions-8",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-none-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        EXPECT_NO_THROW(id->perform_action(fetch_action));
+        ASSERT_NO_THROW(id->perform_action(fetch_action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-mirror-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(fetch_action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(fetch_action));
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -191,12 +191,32 @@ TEST(ERepository, InstallEAPI8)
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions-8",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions-hasq-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        ASSERT_TRUE(pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions-hasv-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions-useq-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(pretend_action.failed());
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -86,7 +86,7 @@ namespace
     {
         return wp_yes;
     }
-
+}
 
 TEST(ERepository, InstallEAPI8)
 {

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -1,0 +1,272 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2006, 2007, 2008, 2009, 2010, 2011, 2012 Ciaran McCreesh
+ * Copyright (c) 2015 David Leverton
+ *
+ * This file is part of the Paludis package manager. Paludis is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * Paludis is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <paludis/repositories/e/e_repository.hh>
+#include <paludis/repositories/e/e_repository_exceptions.hh>
+#include <paludis/repositories/e/e_repository_id.hh>
+#include <paludis/repositories/e/vdb_repository.hh>
+#include <paludis/repositories/e/eapi.hh>
+#include <paludis/repositories/e/spec_tree_pretty_printer.hh>
+
+#include <paludis/repositories/fake/fake_installed_repository.hh>
+#include <paludis/repositories/fake/fake_package_id.hh>
+
+#include <paludis/environments/test/test_environment.hh>
+
+
+#include <paludis/util/system.hh>
+#include <paludis/util/visitor_cast.hh>
+#include <paludis/util/map.hh>
+#include <paludis/util/make_named_values.hh>
+#include <paludis/util/set.hh>
+#include <paludis/util/safe_ifstream.hh>
+#include <paludis/util/stringify.hh>
+
+#include <paludis/standard_output_manager.hh>
+#include <paludis/package_id.hh>
+#include <paludis/metadata_key.hh>
+#include <paludis/action.hh>
+#include <paludis/user_dep_spec.hh>
+#include <paludis/generator.hh>
+#include <paludis/filter.hh>
+#include <paludis/filtered_generator.hh>
+#include <paludis/selection.hh>
+#include <paludis/repository_factory.hh>
+#include <paludis/choice.hh>
+#include <paludis/slot.hh>
+#include <paludis/unformatted_pretty_printer.hh>
+
+#include "config.h"
+
+#include <gtest/gtest.h>
+
+using namespace paludis;
+
+namespace
+{
+    void cannot_uninstall(const std::shared_ptr<const PackageID> & id, const UninstallActionOptions &)
+    {
+        if (id)
+            throw InternalError(PALUDIS_HERE, "cannot uninstall");
+    }
+
+    std::shared_ptr<OutputManager> make_standard_output_manager(const Action &)
+    {
+        return std::make_shared<StandardOutputManager>();
+    }
+
+    std::string from_keys(const std::shared_ptr<const Map<std::string, std::string> > & m,
+            const std::string & k)
+    {
+        Map<std::string, std::string>::ConstIterator mm(m->find(k));
+        if (m->end() == mm)
+            return "";
+        else
+            return mm->second;
+    }
+
+    WantPhase want_all_phases(const std::string &)
+    {
+        return wp_yes;
+    }
+
+
+TEST(ERepository, InstallEAPI8)
+{
+    TestEnvironment env;
+    FSPath cwd(FSPath::cwd());
+    FSPath test_dir(cwd / (std::string(::testing::UnitTest::GetInstance()->current_test_case()->name()) + '.' + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +"_dir"));
+
+    std::shared_ptr<Map<std::string, std::string> > keys(std::make_shared<Map<std::string, std::string>>());
+    keys->insert("format", "e");
+    keys->insert("names_cache", "/var/empty");
+    keys->insert("location", stringify(cwd / "e_repository_TEST_8_dir" / "repo"));
+    keys->insert("profiles", stringify(cwd / "e_repository_TEST_8_dir" / "repo/profiles/profile"));
+    keys->insert("layout", "traditional");
+    keys->insert("eapi_when_unknown", "0");
+    keys->insert("eapi_when_unspecified", "0");
+    keys->insert("profile_eapi", "0");
+    keys->insert("distdir", stringify(cwd / "e_repository_TEST_8_dir" / "distdir"));
+    keys->insert("builddir", stringify(cwd / "e_repository_TEST_8_dir" / "build"));
+    std::shared_ptr<Repository> repo(ERepository::repository_factory_create(&env,
+                std::bind(from_keys, keys, std::placeholders::_1)));
+    env.add_repository(1, repo);
+
+    std::shared_ptr<FakeInstalledRepository> installed_repo(std::make_shared<FakeInstalledRepository>(
+                make_named_values<FakeInstalledRepositoryParams>(
+                    n::environment() = &env,
+                    n::name() = RepositoryName("installed"),
+                    n::suitable_destination() = true,
+                    n::supports_uninstall() = true
+                    )));
+    env.add_repository(2, installed_repo);
+
+    InstallAction install_action(make_named_values<InstallActionOptions>(
+                n::destination() = installed_repo,
+                n::make_output_manager() = &make_standard_output_manager,
+                n::perform_uninstall() = &cannot_uninstall,
+                n::replacing() = std::make_shared<PackageIDSequence>(),
+                n::want_phase() = &want_all_phases
+            ));
+
+    PretendAction pretend_action(make_named_values<PretendActionOptions>(
+                n::destination() = installed_repo,
+                n::make_output_manager() = &make_standard_output_manager,
+                n::replacing() = std::make_shared<PackageIDSequence>()
+                ));
+
+    FetchAction fetch_action(make_named_values<FetchActionOptions>(
+              n::errors() = std::make_shared<Sequence<FetchActionFailure>>(),
+              n::exclude_unmirrorable() = false,
+              n::fetch_parts() = FetchParts() + fp_regulars + fp_extras,
+              n::ignore_not_in_manifest() = false,
+              n::ignore_unfetched() = false,
+              n::make_output_manager() = &make_standard_output_manager,
+              n::safe_resume() = true,
+              n::want_phase() = &want_all_phases
+          ));
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/bash-compat-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/econf-added-options-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(install_action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/changed-opts-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(install_action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/dosym-rel-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(install_action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/fetch-restrictions-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_NO_THROW(id->perform_action(fetch_action));
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/banned-functions-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/changed-vars-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/patches-no-opts-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_THROW(id->perform_action(install_action), ActionFailedError);
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/accumulated-vars-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/test-network-8",
+                                  &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/unpack-formats-removed-8",
+                                  &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        ASSERT_NO_THROW(id->perform_action(install_action));
+    }
+
+    {
+        auto env_copy = env;
+        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("flag"), true);
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/usev-second-arg-8",
+                                  &env_copy, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/pkg-empty-dir-8",
+                                  &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        id->perform_action(pretend_action);
+        ASSERT_TRUE(! pretend_action.failed());
+        ASSERT_NO_THROW(id->perform_action(install_action));
+    }
+}

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -267,13 +267,15 @@ TEST(ERepository, InstallEAPI8)
     }
 
     {
+        auto env_copy = env;
+        env_copy.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), true);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/test-network-8",
-                                  &env, { })), nullptr, { }))]->last());
+                                  &env_copy, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(!!id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("build_options:optional_tests")));
+        ASSERT_NO_THROW(id->perform_action(install_action));
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -200,7 +200,25 @@ TEST(ERepository, InstallEAPI8)
 
     {
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
-                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-8",
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-nolabels-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_THROW(id->perform_action(fetch_action), ActionFailedError);
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-nolabel-alllabels-8",
+                                &env, { })), nullptr, { }))]->last());
+        ASSERT_TRUE(bool(id));
+        EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
+        EXPECT_THROW(id->perform_action(fetch_action), ActionFailedError);
+    }
+
+    {
+        const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
+                        PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-alllabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -92,7 +92,7 @@ TEST(ERepository, InstallEAPI8)
 {
     TestEnvironment env;
     FSPath cwd(FSPath::cwd());
-    FSPath test_dir(cwd / (std::string(::testing::UnitTest::GetInstance()->current_test_case()->name()) + '.' + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +"_dir"));
+    // FSPath test_dir(cwd / (std::string(::testing::UnitTest::GetInstance()->current_test_case()->name()) + '.' + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +"_dir"));
 
     std::shared_ptr<Map<std::string, std::string> > keys(std::make_shared<Map<std::string, std::string>>());
     keys->insert("format", "e");

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -181,48 +181,63 @@ TEST(ERepository, InstallEAPI8)
     }
 
     {
+        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
+                                    "distdir-restrict-none").c_str() , 1);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-none-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(fetch_action));
+        unsetenv("DISTDIR");
     }
 
     {
+        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
+                                    "distdir-restrict-mirror").c_str() , 1);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-mirror-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(fetch_action));
+        unsetenv("DISTDIR");
     }
 
     {
+        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
+                                    "distdir-restrict-fetch-nolabels").c_str() , 1);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-nolabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_THROW(id->perform_action(fetch_action), ActionFailedError);
+        unsetenv("DISTDIR");
     }
 
     {
+        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
+                                    "distdir-restrict-fetch-nolabel-alllabels").c_str() , 1);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-nolabel-alllabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_THROW(id->perform_action(fetch_action), ActionFailedError);
+        unsetenv("DISTDIR");
     }
 
     {
+        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
+                                    "distdir-restrict-fetch-alllabels").c_str() , 1);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-alllabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(fetch_action));
+        unsetenv("DISTDIR");
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -55,6 +55,9 @@
 
 #include "config.h"
 
+#include <ftw.h>
+#include <cstdio>
+
 #include <gtest/gtest.h>
 
 using namespace paludis;
@@ -85,6 +88,25 @@ namespace
     WantPhase want_all_phases(const std::string &)
     {
         return wp_yes;
+    }
+
+    int clear_distdir_it_f(const char * path,
+                           const struct stat *,
+                           int type,
+                           struct FTW * ftw_buf)
+    {
+        if ((::FTW_DP == type) && (0 == ftw_buf->level)) {
+            return(1);
+        }
+        else {
+            std::remove(path);
+        }
+        return(0);
+    }
+
+    void clear_distdir(const std::string & distdir)
+    {
+        ::nftw(distdir.c_str(), &clear_distdir_it_f, 10, (::FTW_DEPTH | ::FTW_PHYS));
     }
 }
 
@@ -181,63 +203,53 @@ TEST(ERepository, InstallEAPI8)
     }
 
     {
-        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
-                                    "distdir-restrict-none").c_str() , 1);
+        clear_distdir(keys->find("distdir")->second);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-none-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(fetch_action));
-        unsetenv("DISTDIR");
     }
 
     {
-        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
-                                    "distdir-restrict-mirror").c_str() , 1);
+        clear_distdir(keys->find("distdir")->second);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-mirror-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(fetch_action));
-        unsetenv("DISTDIR");
     }
 
     {
-        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
-                                    "distdir-restrict-fetch-nolabels").c_str() , 1);
+        clear_distdir(keys->find("distdir")->second);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-nolabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_THROW(id->perform_action(fetch_action), ActionFailedError);
-        unsetenv("DISTDIR");
     }
 
     {
-        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
-                                    "distdir-restrict-fetch-nolabel-alllabels").c_str() , 1);
+        clear_distdir(keys->find("distdir")->second);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-nolabel-alllabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_THROW(id->perform_action(fetch_action), ActionFailedError);
-        unsetenv("DISTDIR");
     }
 
     {
-        setenv("DISTDIR", stringify(cwd / "e_repository_TEST_8_dir" /
-                                    "distdir-restrict-fetch-alllabels").c_str() , 1);
+        clear_distdir(keys->find("distdir")->second);
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/restrict-fetch-alllabels-8",
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_NO_THROW(id->perform_action(fetch_action));
-        unsetenv("DISTDIR");
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -150,7 +150,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -159,7 +159,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(install_action));
+        EXPECT_NO_THROW(id->perform_action(install_action));
     }
 
     {
@@ -168,7 +168,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(install_action));
+        EXPECT_NO_THROW(id->perform_action(install_action));
     }
 
     {
@@ -177,7 +177,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(install_action));
+        EXPECT_NO_THROW(id->perform_action(install_action));
     }
 
     {
@@ -186,7 +186,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(fetch_action));
+        EXPECT_NO_THROW(id->perform_action(fetch_action));
     }
 
     {
@@ -195,7 +195,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(fetch_action));
+        EXPECT_NO_THROW(id->perform_action(fetch_action));
     }
 
     {
@@ -204,7 +204,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(fetch_action));
+        EXPECT_NO_THROW(id->perform_action(fetch_action));
     }
 
     {
@@ -214,7 +214,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(pretend_action.failed());
+        EXPECT_TRUE(pretend_action.failed());
     }
 
     {
@@ -224,7 +224,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(pretend_action.failed());
+        EXPECT_TRUE(pretend_action.failed());
     }
 
     {
@@ -234,7 +234,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(pretend_action.failed());
+        EXPECT_TRUE(pretend_action.failed());
     }
 
     {
@@ -244,7 +244,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -253,7 +253,7 @@ TEST(ERepository, InstallEAPI8)
                                 &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_THROW(id->perform_action(install_action), ActionFailedError);
+        EXPECT_THROW(id->perform_action(install_action), ActionFailedError);
     }
 
     {
@@ -263,7 +263,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -275,7 +275,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_TRUE(!!id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("build_options:optional_tests")));
-        ASSERT_NO_THROW(id->perform_action(install_action));
+        EXPECT_NO_THROW(id->perform_action(install_action));
     }
 
     {
@@ -284,7 +284,7 @@ TEST(ERepository, InstallEAPI8)
                                   &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
-        ASSERT_NO_THROW(id->perform_action(install_action));
+        EXPECT_NO_THROW(id->perform_action(install_action));
     }
 
     {
@@ -296,7 +296,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
+        EXPECT_TRUE(! pretend_action.failed());
     }
 
     {
@@ -306,7 +306,7 @@ TEST(ERepository, InstallEAPI8)
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
-        ASSERT_TRUE(! pretend_action.failed());
-        ASSERT_NO_THROW(id->perform_action(install_action));
+        EXPECT_TRUE(! pretend_action.failed());
+        EXPECT_NO_THROW(id->perform_action(install_action));
     }
 }

--- a/paludis/repositories/e/e_repository_TEST_8.cc
+++ b/paludis/repositories/e/e_repository_TEST_8.cc
@@ -300,15 +300,17 @@ TEST(ERepository, InstallEAPI8)
     }
 
     {
-        auto env_copy = env;
-        env_copy.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), true);
+        env.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), true);
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/test-network-8",
-                                  &env_copy, { })), nullptr, { }))]->last());
+                                  &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         EXPECT_TRUE(!!id->choices_key()->parse_value()->find_by_name_with_prefix(ChoiceNameWithPrefix("build_options:optional_tests")));
         EXPECT_NO_THROW(id->perform_action(install_action));
+
+        env.set_want_choice_enabled(ChoicePrefixName("build_options"), UnprefixedChoiceName("optional_tests"), false);
     }
 
     {
@@ -321,15 +323,17 @@ TEST(ERepository, InstallEAPI8)
     }
 
     {
-        auto env_copy = env;
-        env_copy.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("flag"), true);
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("flag"), true);
+
         const std::shared_ptr<const PackageID> id(*env[selection::RequireExactlyOne(generator::Matches(
                         PackageDepSpec(parse_user_package_dep_spec("=cat/usev-second-arg-8",
-                                  &env_copy, { })), nullptr, { }))]->last());
+                                  &env, { })), nullptr, { }))]->last());
         ASSERT_TRUE(bool(id));
         EXPECT_EQ("8", visitor_cast<const MetadataValueKey<std::string> >(**id->find_metadata("EAPI"))->parse_value());
         id->perform_action(pretend_action);
         EXPECT_TRUE(! pretend_action.failed());
+
+        env.set_want_choice_enabled(ChoicePrefixName(""), UnprefixedChoiceName("flag"), false);
     }
 
     {

--- a/paludis/repositories/e/e_repository_TEST_8_cleanup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# vim: set ft=sh sw=4 sts=4 et :
+
+if [ -d e_repository_TEST_8_dir ] ; then
+    rm -fr e_repository_TEST_8_dir
+else
+    true
+fi
+

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -377,6 +377,7 @@ SLOT="0"
 IUSE="flag"
 LICENSE="GPL-2"
 KEYWORDS="test"
+RESTRICT='test'
 PROPERTIES="test_network"
 
 pkg_pretend() {

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -218,10 +218,8 @@ RESTRICT="fetch mirror"
 END
 
 # hasq banned
-# hasv banned
-# useq banned
-mkdir -p "cat/banned-functions"
-cat <<'END' > cat/banned-functions/banned-functions-8.ebuild
+mkdir -p "cat/banned-functions-hasq"
+cat <<'END' > cat/banned-functions-hasq/banned-functions-hasq-8.ebuild
 EAPI="8"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
@@ -234,9 +232,45 @@ KEYWORDS="test"
 S="${WORKDIR}"
 
 pkg_pretend() {
-    [[ -n "$(declare -F hasq)" ]] && die 'hasq is banned'
-    [[ -n "$(declare -F hasv)" ]] && die 'hasv is banned'
-    [[ -n "$(declare -F useq)" ]] && die 'useq is banned'
+    hasq 'a' 'a'
+}
+END
+
+# hasv banned
+mkdir -p "cat/banned-functions-hasv"
+cat <<'END' > cat/banned-functions-hasv/banned-functions-hasv-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    hasv 'a' 'a'
+}
+END
+
+# useq banned
+mkdir -p "cat/banned-functions-useq"
+cat <<'END' > cat/banned-functions-useq/banned-functions-useq-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    useq '!spork'
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -216,7 +216,7 @@ cat <<END > cat/restrict-none/restrict-none-8.ebuild
 EAPI="8"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
-SRC_URI="file://${MIRROR}/test1.tar.xz"
+SRC_URI="file://${MIRROR}/test1.tar.xz fetch+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
 SLOT="0"
 IUSE="spork"
 LICENSE="GPL-2"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -91,23 +91,41 @@ src_prepare(){
     cat <<'EOF' > configure
 #!/bin/sh
 
-if echo "$@" | grep -q 'help' ; then
-    echo --datarootdir
-    echo --disable-static
-    exit 0
+param=''
+for param in "${@}"; do
+    if [ '--help' = "${param}" ]; then
+        printf '%s\n' '--datarootdir'
+        printf '%s\n' '--disable-static'
+        exit 0
+    fi
+done
+
+param=''
+datarootdir='0'
+disablestatic='0'
+for param in "${@}"; do
+    if [ "--datarootdir=${EPREFIX}/usr/share" = "${param}" ]; then
+        datarootdir='1'
+    fi
+
+    if [ '--disable-static' = "${param}" ]; then
+        disablestatic='1'
+    fi
+
+    if [ '1' = "${datarootdir}" ] && [ '1' = "${disablestatic}" ]; then
+        exit '0'
+    fi
+done
+
+if [ '0' = "${datarootdir}" ]; then
+    printf '%s missing\n' '--datarootdir'
 fi
 
-if ! echo "$@" | grep -q datarootdir="${EPREFIX}"/usr/share ; then
-    echo --datarootdir missing
-    exit 1
+if [ '0' = "${disablestatic}" ]; then
+    printf '%s missing\n' '--disable-static'
 fi
 
-if ! echo "$@" | grep -q 'disable-static' ; then
-    echo --disable-static missing
-    exit 1
-fi
-
-exit 0
+exit '1'
 EOF
 
     chmod +x configure

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -393,7 +393,6 @@ END
 
 # PROPERTIES now accumulated across eclasses
 # RESTRICT now accumulated across eclasses
-# TODO
 cat <<'END' > eclass/foo.eclass
 PROPERTIES="FOO"
 RESTRICT="FOO"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -201,13 +201,14 @@ END
 
 # fetch+ SRC_URI prefix to override fetch restriction
 # mirror+ SRC_URI prefix to override mirror restriction
-# TODO
+# TODO: this seems to fail currently, revisit and fix the implementation,
+#       since the test looks fine.
 mkdir -p "cat/fetch-restrictions"
 cat <<'END' > cat/fetch-restrictions/fetch-restrictions-8.ebuild
 EAPI="8"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
-SRC_URI="fetch+test.7z mirror+test.rar"
+SRC_URI="fetch+test.tgz mirror+test.tbz2"
 SLOT="0"
 IUSE="spork"
 LICENSE="GPL-2"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -372,7 +372,7 @@ PATCHES=( -p0 "${FILESDIR}"/${P}-foo.patch )
 S="${WORKDIR}"
 
 src_unpack() {
-    echo first >file || die
+    echo first > file || die
 }
 
 src_compile() {

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -222,18 +222,6 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 RESTRICT=""
-
-pkg_nofetch() {
-    env|sort
-    [[ -z \${A} ]] && return
-
-    elog "The following files cannot be fetched for \${PN}:"
-    local x
-    for x in \${A}; do
-        elog "   \${x}"
-    done
-    die failed to fetch
-}
 END
 
 # mirror | (none) / fetch+ |  allowed | prohibited
@@ -249,16 +237,6 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 RESTRICT="mirror"
-
-pkg_nofetch() {
-    [[ -z \${A} ]] && return
-
-    elog "The following files cannot be fetched for \${PN}:"
-    local x
-    for x in \${A}; do
-        elog "   \${x}"
-    done
-}
 END
 
 # fetch | (none) | prohibited | prohibited
@@ -275,16 +253,6 @@ IUSE="spork"
 LICENSE="GPL-2"
 KEYWORDS="test"
 RESTRICT="fetch"
-
-pkg_nofetch() {
-    [[ -z \${A} ]] && return
-
-    elog "The following files cannot be fetched for \${PN}:"
-    local x
-    for x in \${A}; do
-        elog "   \${x}"
-    done
-}
 END
 
 # hasq banned

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -211,6 +211,7 @@ cd ..
 MIRROR="$(realpath mirror)"
 # RESTRICT | "URI prefix" | Fetching | Mirroring
 # (none) | (any) |  allowed  | allowed
+mkdir '../distdir-restrict-none'
 mkdir -p "cat/restrict-none"
 cat <<END > cat/restrict-none/restrict-none-8.ebuild
 EAPI="8"
@@ -226,6 +227,7 @@ END
 
 # mirror | (none) / fetch+ |  allowed | prohibited
 # mirror | mirror+ | allowed | allowed
+mkdir '../distdir-restrict-mirror'
 mkdir -p "cat/restrict-mirror"
 cat <<END > cat/restrict-mirror/restrict-mirror-8.ebuild
 EAPI="8"
@@ -243,6 +245,7 @@ END
 # fetch | fetch+  | allowed | prohibited
 # fetch | mirror+ | allowed | allowed
 # The following test should fail.
+mkdir '../distdir-restrict-fetch-nolabels'
 mkdir -p "cat/restrict-fetch-nolabels"
 cat <<END > cat/restrict-fetch-nolabels/restrict-fetch-nolabels-8.ebuild
 EAPI="8"
@@ -257,6 +260,7 @@ RESTRICT="fetch"
 END
 # This one should fail, too, because the first distfile should never be
 # fetchable.
+mkdir '../distdir-restrict-fetch-nolabel-alllabels'
 mkdir -p "cat/restrict-fetch-nolabel-alllabels"
 cat <<END > cat/restrict-fetch-nolabel-alllabels/restrict-fetch-nolabel-alllabels-8.ebuild
 EAPI="8"
@@ -271,6 +275,7 @@ RESTRICT="fetch"
 END
 # This one should work, since it contains no unprefixed distfile and any
 # prefix is able to override the restriction.
+mkdir '../distdir-restrict-fetch-alllabels'
 mkdir -p "cat/restrict-fetch-alllabels"
 cat <<END > cat/restrict-fetch-alllabels/restrict-fetch-alllabels-8.ebuild
 EAPI="8"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -496,7 +496,6 @@ pkg_pretend() {
 END
 
 # working directory pkg_* phases now start in an empty directory
-# TODO
 mkdir -p "cat/pkg-empty-dir"
 cat <<'END' > cat/pkg-empty-dir/pkg-empty-dir-8.ebuild
 EAPI="8"
@@ -520,13 +519,13 @@ test_impl() {
     touch 'force-non-empty' || :
 }
 
-pkg_config() { test_impl; }
-pkg_info() { test_impl; }
-pkg_nofetch() { test_impl; }
+pkg_config()   { test_impl; }
+pkg_info()     { test_impl; }
+pkg_nofetch()  { test_impl; }
 pkg_postinst() { test_impl; }
-pkg_postrm() { test_impl; }
-pkg_preinst() { test_impl; }
-pkg_prerm() { test_impl; }
-pkg_setup() { test_impl; }
-pkg_pretend() { test_impl; }
+pkg_postrm()   { test_impl; }
+pkg_preinst()  { test_impl; }
+pkg_prerm()    { test_impl; }
+pkg_setup()    { test_impl; }
+pkg_pretend()  { test_impl; }
 END

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -234,9 +234,9 @@ KEYWORDS="test"
 S="${WORKDIR}"
 
 pkg_pretend() {
-    [[ -n "$(declare -F hasq)" ]]  && die 'hasq is banned'
-    [[ -n "$(declare -F hasv)" ]]  && die 'hasv is banned'
-    [[ -n "$(declare -F useq)" ]]  && die 'useq is banned'
+    [[ -n "$(declare -F hasq)" ]] && die 'hasq is banned'
+    [[ -n "$(declare -F hasv)" ]] && die 'hasv is banned'
+    [[ -n "$(declare -F useq)" ]] && die 'useq is banned'
 }
 END
 
@@ -253,9 +253,9 @@ LICENSE="GPL-2"
 KEYWORDS="test"
 
 pkg_pretend() {
-for var in IDEPEND; do
-  [ -z "${!var+x}" ] && echo "${var} has been added and should be set"
-done
+    for var in IDEPEND; do
+        [ -z "${!var+x}" ] && echo "${var} has been added and should be set"
+    done
 }
 END
 
@@ -368,7 +368,6 @@ src_unpack() {
         nonfatal unpack test.${format} 2> /dev/null > /dev/null
         [[ '0' -eq "$?" ]] && die "${format} should not be unpacked"
     done
-
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -453,7 +453,6 @@ src_install() {
 END
 
 # unpack no longer supports 7-Zip, LHA and RAR formats
-# TODO
 mkdir -p "cat/unpack-formats-removed"
 cat <<'END' > cat/unpack-formats-removed/unpack-formats-removed-8.ebuild
 EAPI="8"
@@ -464,6 +463,7 @@ SLOT="0"
 IUSE="flag"
 LICENSE="GPL-2"
 KEYWORDS="test"
+
 S="${WORKDIR}"
 
 src_unpack() {

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -218,6 +218,9 @@ DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
 SRC_URI="file://${MIRROR}/test1.tar.xz"
 SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
 RESTRICT=""
 
 pkg_nofetch() {
@@ -242,6 +245,9 @@ DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
 SRC_URI="file://${MIRROR}/test1.tar.xz fetch+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
 SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
 RESTRICT="mirror"
 
 pkg_nofetch() {
@@ -265,6 +271,9 @@ DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
 SRC_URI="file://${MIRROR}/test1.tar.xz file+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
 SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
 RESTRICT="fetch"
 
 pkg_nofetch() {

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -67,7 +67,7 @@ KEYWORDS="test"
 S="${WORKDIR}"
 
 pkg_pretend() {
-    echo "${PALUDIS_BASH_COMPAT}"
+    [[ "${BASH_COMPAT}" == '5.0' ]] || [[ "${BASH_COMPAT}" == '50' ]] || die "BASH_COMPAT=${BASH_COMPAT}"
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -242,12 +242,41 @@ END
 # fetch | (none) | prohibited | prohibited
 # fetch | fetch+  | allowed | prohibited
 # fetch | mirror+ | allowed | allowed
-mkdir -p "cat/restrict-fetch"
-cat <<END > cat/restrict-fetch/restrict-fetch-8.ebuild
+# The following test should fail.
+mkdir -p "cat/restrict-fetch-nolabels"
+cat <<END > cat/restrict-fetch-nolabels/restrict-fetch-nolabels-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI="file://${MIRROR}/test1.tar.xz"
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+RESTRICT="fetch"
+END
+# This one should fail, too, because the first distfile should never be
+# fetchable.
+mkdir -p "cat/restrict-fetch-nolabel-alllabels"
+cat <<END > cat/restrict-fetch-nolabel-alllabels/restrict-fetch-nolabel-alllabels-8.ebuild
 EAPI="8"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
 SRC_URI="file://${MIRROR}/test1.tar.xz fetch+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+RESTRICT="fetch"
+END
+# This one should work, since it contains no unprefixed distfile and any
+# prefix is able to override the restriction.
+mkdir -p "cat/restrict-fetch-alllabels"
+cat <<END > cat/restrict-fetch-alllabels/restrict-fetch-alllabels-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI="fetch+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
 SLOT="0"
 IUSE="spork"
 LICENSE="GPL-2"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# vim: set ft=sh sw=4 sts=4 et :
+
+set -e
+
+mkdir e_repository_TEST_8_dir
+cd e_repository_TEST_8_dir
+
+mkdir -p root/etc
+
+mkdir -p vdb
+touch vdb/THISISTHEVDB
+
+mkdir -p build
+
+mkdir -p distdir
+
+for format in 7z lha lzh rar; do
+    touch "distdir/test.${format}"
+done
+
+mkdir -p repo/{profiles/profile,metadata,eclass}
+cd repo
+echo "test-repo" >> profiles/repo_name
+cat <<'END' > profiles/arch.list
+amd64
+arm
+arm64
+x86
+
+# Prefix keywords
+amd64-linux
+arm-linux
+arm64-linux
+x86-linux
+END
+
+echo "cat" >> profiles/categories
+cat <<'END' > profiles/profile/make.defaults
+ARCH="cheese"
+USERLAND="GNU"
+KERNEL="linux"
+LIBC="glibc"
+CHOST="i286-badger-linux-gnu"
+LINGUAS="enabled_en enabled_en_GB enabled_en_GB@UTF-8"
+USE_EXPAND="LINGUAS USERLAND"
+USE_EXPAND_UNPREFIXED="ARCH"
+USE_EXPAND_IMPLICIT="USERLAND ARCH"
+USE_EXPAND_VALUES_USERLAND="GNU"
+USE_EXPAND_VALUES_ARCH="cheese otherarch"
+IUSE_IMPLICIT="build"
+END
+
+# bash 5.0 is now sanctioned
+# PALUDIS_BASH_COMPAT
+mkdir -p "cat/bash-compat"
+cat <<'END' > cat/bash-compat/bash-compat-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    echo "${PALUDIS_BASH_COMPAT}"
+}
+END
+
+# econf passes --build, --target, --with-sysroot
+# --datarootdir new econf-passed option
+# --disable-static new econf-passed option
+mkdir -p "cat/econf-added-options"
+cat <<'END' > cat/econf-added-options/econf-added-options-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_prepare(){
+    cat <<'EOF' > configure
+#!/bin/sh
+
+if echo "$@" | grep -q 'help' ; then
+    echo --datarootdir
+    echo --disable-static
+    exit 0
+fi
+
+if ! echo "$@" | grep -q datarootdir="${EPREFIX}"/usr/share ; then
+    echo --datarootdir missing
+    exit 1
+fi
+
+if ! echo "$@" | grep -q 'disable-static' ; then
+    echo --disable-static missing
+    exit 1
+fi
+
+exit 0
+EOF
+
+    chmod +x configure
+}
+END
+
+# doconfd no longer affected by insopts
+# doenvd no longer affected by insopts
+# doheader no longer affected by insopts
+# doinitd no longer affected by exeopts
+mkdir -p "cat/changed-opts"
+cat <<'END' > cat/changed-opts/changed-opts-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_install() {
+   insopts --foo
+   exeopts --bar
+   echo foo > foo
+   doconfd foo
+   doenvd foo
+   doheader foo
+   doinitd foo
+}
+END
+
+# dosym -r allows creating relative symlinks
+mkdir -p "cat/dosym-rel"
+cat <<'END' > cat/dosym-rel/dosym-rel-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+src_install() {
+    echo bar > bar
+    dobin bar
+    dosym ${D}/usr/bin/bar /usr/bin/foo
+    [[ "$(readlink "${D}/usr/bin/bar")" == "foo" ]] || die 'link wrong'
+}
+END
+
+# fetch+ SRC_URI prefix to override fetch restriction
+# mirror+ SRC_URI prefix to override mirror restriction
+# TODO
+mkdir -p "cat/fetch-restrictions"
+cat <<'END' > cat/fetch-restrictions/fetch-restrictions-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI="fetch+test.7z mirror+test.rar"
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+RESTRICT="fetch mirror"
+
+END
+
+# hasq banned
+# hasv banned
+# useq banned
+mkdir -p "cat/banned-functions"
+cat <<'END' > cat/banned-functions/banned-functions-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="spork"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+S="${WORKDIR}"
+
+pkg_pretend() {
+    [[ -n "$(declare -F hasq)" ]]  && die 'hasq is banned'
+    [[ -n "$(declare -F hasv)" ]]  && die 'hasv is banned'
+    [[ -n "$(declare -F useq)" ]]  && die 'useq is banned'
+}
+END
+
+# IDEPEND new dependency type for pkg_postinst deps
+mkdir -p "cat/changed-vars"
+cat <<'END' > cat/changed-vars/changed-vars-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+pkg_pretend() {
+for var in IDEPEND; do
+  [ -z "${!var+x}" ] && echo "${var} has been added and should be set"
+done
+}
+END
+
+# PATCHES no longer permits specifying options (paths only)
+mkdir -p "cat/patches-no-opts"
+cat <<'END' > cat/patches-no-opts/patches-no-opts-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+PATCHES=( -p0 "${FILESDIR}"/${P}-foo.patch )
+
+S="${WORKDIR}"
+
+src_unpack() {
+    echo first >file || die
+}
+
+src_compile() {
+    [[ "$(< file)" == 'second' ]] || die 'file wrong'
+}
+END
+
+mkdir -p "cat/patches-no-opts/files" || exit 1
+cat << 'END' > cat/patches-no-opts/files/patches-no-opts-8-foo.patch || exit 1
+diff --git a/file b/file
+index 9c59e24..e019be0 100644
+--- a/file
++++ b/file
+@@ -1 +1 @@
+-first
++second
+END
+
+# PROPERTIES now accumulated across eclasses
+# RESTRICT now accumulated across eclasses
+# TODO
+cat <<'END' > eclass/foo.eclass
+PROPERTIES="FOO"
+RESTRICT="FOO"
+END
+cat <<'END' > eclass/bar.eclass
+PROPERTIES="BAR"
+RESTRICT="BAR"
+END
+
+mkdir -p "cat/accumulated-vars"
+cat <<'END' > cat/accumulated-vars/accumulated-vars-8.ebuild
+EAPI="8"
+inherit foo bar
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+pkg_pretend() {
+    [[ "${PROPERTIES}" == *FOO* ]] || die 'failed to accumulate PROPERTIES'
+    [[ "${PROPERTIES}" == *BAR* ]] || die 'failed to accumulate PROPERTIES'
+    [[ "${RESTRICT}" == *FOO* ]] || die 'failed to accumulate RESTRICT'
+    [[ "${RESTRICT}" == *BAR* ]] || die 'failed to accumulate RESTRICT'
+}
+END
+
+# test_network new PROPERTIES value for tests requiring Internet
+mkdir -p "cat/test-network"
+cat <<'END' > cat/test-network/test-network-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="flag"
+LICENSE="GPL-2"
+KEYWORDS="test"
+PROPERTIES="test_network"
+
+pkg_pretend() {
+    die 'not implemented'
+}
+src_prepare() {
+    die 'not implemented'
+}
+END
+
+# unpack no longer supports 7-Zip, LHA and RAR formats
+# TODO
+mkdir -p "cat/unpack-formats-removed"
+cat <<'END' > cat/unpack-formats-removed/unpack-formats-removed-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI="test.7z test.lha test.lzh test.rar"
+SLOT="0"
+IUSE="flag"
+LICENSE="GPL-2"
+KEYWORDS="test"
+S="${WORKDIR}"
+
+src_unpack() {
+    export PALUDIS_UNPACK_UNRECOGNISED_IS_FATAL=yes
+    for format in 7z lha lzh rar; do
+        nonfatal unpack test.${format} 2> /dev/null > /dev/null
+        [[ '0' -eq "$?" ]] && die "${format} should not be unpacked"
+    done
+
+}
+END
+
+# updates filenames no longer have to follow nQ-yyyy style
+# TODO
+
+# usev accepts second argument to override output value
+mkdir -p "cat/usev-second-arg"
+cat <<'END' > cat/usev-second-arg/usev-second-arg-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE="flag"
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+pkg_pretend() {
+    [[ "$(usev flag true)" == "true" ]] || die 'usev second arg no supported'
+}
+END
+
+# working directory pkg_* phases now start in an empty directory
+# TODO
+mkdir -p "cat/pkg-empty-dir"
+cat <<'END' > cat/pkg-empty-dir/pkg-empty-dir-8.ebuild
+EAPI="8"
+DESCRIPTION="The Description"
+HOMEPAGE="http://example.com/"
+SRC_URI=""
+SLOT="0"
+IUSE=""
+LICENSE="GPL-2"
+KEYWORDS="test"
+
+pkg_config() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_info() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_nofetch() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_postinst() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_postrm() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_preinst() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_prerm() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_setup() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+pkg_pretend() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+END

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -369,13 +369,25 @@ IUSE=""
 LICENSE="GPL-2"
 KEYWORDS="test"
 
-pkg_config() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_info() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_nofetch() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_postinst() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_postrm() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_preinst() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_prerm() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_setup() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
-pkg_pretend() { [[ "$(find . | wc -l)" -gt '1' ]] && die "$(pwd) not empty"; }
+test_impl() {
+    if [[ "$(find . | wc -l)" -gt '1' ]]; then
+        die "$(pwd) not empty"
+    fi
+
+    # Try to make the cwd dirty to check if subsequent pkg_* phases find it
+    # empty again.
+    # However, while the directory must be empty, it need not be writable, so
+    # accept failures.
+    touch 'force-non-empty' || :
+}
+
+pkg_config() { test_impl; }
+pkg_info() { test_impl; }
+pkg_nofetch() { test_impl; }
+pkg_postinst() { test_impl; }
+pkg_postrm() { test_impl; }
+pkg_preinst() { test_impl; }
+pkg_prerm() { test_impl; }
+pkg_setup() { test_impl; }
+pkg_pretend() { test_impl; }
 END

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -211,7 +211,6 @@ cd ..
 MIRROR="$(realpath mirror)"
 # RESTRICT | "URI prefix" | Fetching | Mirroring
 # (none) | (any) |  allowed  | allowed
-mkdir '../distdir-restrict-none'
 mkdir -p "cat/restrict-none"
 cat <<END > cat/restrict-none/restrict-none-8.ebuild
 EAPI="8"
@@ -227,7 +226,6 @@ END
 
 # mirror | (none) / fetch+ |  allowed | prohibited
 # mirror | mirror+ | allowed | allowed
-mkdir '../distdir-restrict-mirror'
 mkdir -p "cat/restrict-mirror"
 cat <<END > cat/restrict-mirror/restrict-mirror-8.ebuild
 EAPI="8"
@@ -245,7 +243,6 @@ END
 # fetch | fetch+  | allowed | prohibited
 # fetch | mirror+ | allowed | allowed
 # The following test should fail.
-mkdir '../distdir-restrict-fetch-nolabels'
 mkdir -p "cat/restrict-fetch-nolabels"
 cat <<END > cat/restrict-fetch-nolabels/restrict-fetch-nolabels-8.ebuild
 EAPI="8"
@@ -260,7 +257,6 @@ RESTRICT="fetch"
 END
 # This one should fail, too, because the first distfile should never be
 # fetchable.
-mkdir '../distdir-restrict-fetch-nolabel-alllabels'
 mkdir -p "cat/restrict-fetch-nolabel-alllabels"
 cat <<END > cat/restrict-fetch-nolabel-alllabels/restrict-fetch-nolabel-alllabels-8.ebuild
 EAPI="8"
@@ -275,7 +271,6 @@ RESTRICT="fetch"
 END
 # This one should work, since it contains no unprefixed distfile and any
 # prefix is able to override the restriction.
-mkdir '../distdir-restrict-fetch-alllabels'
 mkdir -p "cat/restrict-fetch-alllabels"
 cat <<END > cat/restrict-fetch-alllabels/restrict-fetch-alllabels-8.ebuild
 EAPI="8"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -247,7 +247,7 @@ cat <<END > cat/restrict-fetch/restrict-fetch-8.ebuild
 EAPI="8"
 DESCRIPTION="The Description"
 HOMEPAGE="http://example.com/"
-SRC_URI="file://${MIRROR}/test1.tar.xz file+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
+SRC_URI="file://${MIRROR}/test1.tar.xz fetch+file://${MIRROR}/test2.tar.xz mirror+file://${MIRROR}/test3.tar.xz"
 SLOT="0"
 IUSE="spork"
 LICENSE="GPL-2"

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -185,16 +185,25 @@ dosym_relative_path_pms() {
 
 src_install() {
     echo foo > foo
+    echo frob > frobnicate
     dobin foo
+    insinto "${EPREFIX}/usr/lib/frobnicate"
+    insopts -m0755
+    doins frobnicate
     dosym "${EPREFIX}/usr/bin/foo" '/usr/bin/bar'
     dosym -r "${EPREFIX}/usr/bin/foo" '/usr/bin/baz'
+    dosym -r "${EPREFIX}/usr/lib/frobnicate/frobnicate" '/usr/bin/frobnicate'
 
     real_target="$(readlink "${D}/usr/bin/bar")"
     expected_target="${EPREFIX}/usr/bin/foo"
     [ "${expected_target}" = "${real_target}" ] || die "absolute link wrong; is: '${real_target}', should have been: '${expected_target}'"
 
     real_target="$(readlink "${D}/usr/bin/baz")"
-    expected_target="foo"
+    expected_target='foo'
+    [ "${expected_target}" = "${real_target}" ] || die "relative link wrong; is: '${real_target}', should have been: '${expected_target}'"
+
+    real_target="$(readlink "${D}/usr/bin/frobnicate")"
+    expected_target='../lib/frobnicate/frobnicate'
     [ "${expected_target}" = "${real_target}" ] || die "relative link wrong; is: '${real_target}', should have been: '${expected_target}'"
 }
 END

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -346,6 +346,7 @@ SLOT="0"
 IUSE=""
 LICENSE="GPL-2"
 KEYWORDS="test"
+IDEPEND="foo"
 
 pkg_pretend() {
     for var in IDEPEND; do

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -353,11 +353,16 @@ IUSE=""
 LICENSE="GPL-2"
 KEYWORDS="test"
 
+PROPERTIES="BAZ"
+RESTRICT="BAZ"
+
 pkg_pretend() {
     [[ "${PROPERTIES}" == *FOO* ]] || die 'failed to accumulate PROPERTIES'
     [[ "${PROPERTIES}" == *BAR* ]] || die 'failed to accumulate PROPERTIES'
+    [[ "${PROPERTIES}" == *BAZ* ]] || die 'failed to accumulate PROPERTIES'
     [[ "${RESTRICT}" == *FOO* ]] || die 'failed to accumulate RESTRICT'
     [[ "${RESTRICT}" == *BAR* ]] || die 'failed to accumulate RESTRICT'
+    [[ "${RESTRICT}" == *BAZ* ]] || die 'failed to accumulate RESTRICT'
 }
 END
 

--- a/paludis/repositories/e/e_repository_TEST_8_setup.sh
+++ b/paludis/repositories/e/e_repository_TEST_8_setup.sh
@@ -440,12 +440,15 @@ LICENSE="GPL-2"
 KEYWORDS="test"
 RESTRICT='test'
 PROPERTIES="test_network"
+S="${WORKDIR}"
 
-pkg_pretend() {
-    die 'not implemented'
+src_test() {
+    ping -c1 example.invalid
+    export RAN_TEST="true"
 }
-src_prepare() {
-    die 'not implemented'
+
+src_install() {
+    [[ -z "${RAN_TEST}" ]] && die "didn't run network tests"
 }
 END
 


### PR DESCRIPTION
This adds the following tests:
      - bash compat 5.0+
      - `econf` passes `--datarootdir="${EPREFIX}/usr/share"` and `--disable-static` by default
      - `doconfd`, `doenvd`, `doheader` not influenced by `insopts` and `doinitd` not influenced by `exeopts` any longer
      - `dosym -r` for relative symlinks
      - fetch and mirror restriction overrides via `fetch+`/`mirror+` `SRC_URI` prefixes
      - `hasq`, `hasv` and `useq` banned
      - new `IDEPEND` variable, `RDEPEND`-equivalent to `BDEPEND` and `DEPEND`
      - `PATCHES` variable/array does not accept options any longer
      - `PROPERTIES` and `RESTRICT` now accumulate through `eclass`es
      - new optional `test_network` value for `PROPERTIES`, overriding test restrictions
      - `7-Zip`, `LHA` and `RAR` formats dropped from base `unpack`
      - second argument to `usev` function to override output value
      - `pkg_*` phases start in empty directory