### PR TITLE
EAPI=8: actually remove the override prefix from URIs.

### DIFF
--- a/paludis/repositories/e/fetch_visitor.cc
+++ b/paludis/repositories/e/fetch_visitor.cc
@@ -159,7 +159,7 @@ FetchVisitor::visit(const FetchableURISpecTree::NodeType<FetchableURIDepSpec>::T
 
     auto repo(_imp->env->fetch_repository(_imp->id->repository_name()));
     SourceURIFinder source_uri_finder(_imp->env, repo.get(), _imp->eapi,
-            node.spec()->original_url(), node.spec()->filename(), _imp->mirrors_name, _imp->get_mirrors_fn);
+            node.spec()->filename(), _imp->mirrors_name, _imp->get_mirrors_fn, node.spec()->original_url());
     (*_imp->labels.begin())->accept(source_uri_finder);
     for (const auto & uri_to_filename : source_uri_finder)
     {

--- a/paludis/repositories/e/source_uri_finder.cc
+++ b/paludis/repositories/e/source_uri_finder.cc
@@ -47,22 +47,22 @@ namespace paludis
         const Environment * const env;
         const Repository * const repo;
         const EAPI & eapi;
-        const std::string url;
         const std::string filename;
         const std::string mirrors_name;
         const GetMirrorsFunction get_mirrors_fn;
+        std::string url;
 
         Items items;
 
-        Imp(const Environment * const e, const Repository * const r, const EAPI & p,  const std::string & u, const std::string & f,
-                const std::string & m, const GetMirrorsFunction & g) :
+        Imp(const Environment * const e, const Repository * const r, const EAPI & p, const std::string & f,
+                const std::string & m, const GetMirrorsFunction & g, const std::string & u) :
             env(e),
             repo(r),
             eapi(p),
-            url(u),
             filename(f),
             mirrors_name(m),
-            get_mirrors_fn(g)
+            get_mirrors_fn(g),
+            url(u)
         {
         }
     };
@@ -75,8 +75,8 @@ namespace paludis
 }
 
 SourceURIFinder::SourceURIFinder(const Environment * const e, const Repository * const repo, const EAPI & p,
-        const std::string & u, const std::string & f, const std::string & m, const GetMirrorsFunction & g) :
-    _imp(e, repo, p, u, f, m, g)
+        const std::string & f, const std::string & m, const GetMirrorsFunction & g, const std::string & u) :
+    _imp(e, repo, p, f, m, g, u)
 {
 }
 
@@ -102,10 +102,34 @@ namespace
     }
 }
 
+void SourceURIFinder::uri_remove_prefix(const std::string & overridestr) {
+    _imp->url.erase(0, overridestr.size());
+}
+
+void SourceURIFinder::uri_remove_prefixes() {
+    auto mirror_override = std::find_if(_imp->eapi.supported()->ebuild_options()->restrict_mirror_override()->begin(),
+                                _imp->eapi.supported()->ebuild_options()->restrict_mirror_override()->end(),
+                                std::bind(&uri_start_with_override, std::placeholders::_1, _imp->url));
+    auto fetch_override = std::find_if(_imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->begin(),
+                        _imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->end(),
+                        std::bind(&uri_start_with_override, std::placeholders::_1, _imp->url));
+    if (_imp->eapi.supported()->ebuild_options()->restrict_mirror_override()->end() !=
+            mirror_override) {
+        uri_remove_prefix(*mirror_override);
+    }
+    else if (_imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->end() !=
+                fetch_override) {
+        uri_remove_prefix(*fetch_override);
+    }
+}
+
 void
 SourceURIFinder::visit(const URIMirrorsThenListedLabel &)
 {
     Context context("When using URIMirrorsThenListedLabel:");
+
+    uri_remove_prefixes();
+
     add_local_mirrors();
     add_mirrors();
     add_listed();
@@ -115,6 +139,9 @@ void
 SourceURIFinder::visit(const URIListedThenMirrorsLabel &)
 {
     Context context("When using URIListedThenMirrorsLabel:");
+
+    uri_remove_prefixes();
+
     add_local_mirrors();
     add_listed();
     add_mirrors();
@@ -124,6 +151,9 @@ void
 SourceURIFinder::visit(const URIMirrorsOnlyLabel &)
 {
     Context context("When using URIMirrorsOnlyLabel:");
+
+    uri_remove_prefixes();
+
     add_local_mirrors();
     add_mirrors();
 }
@@ -139,11 +169,13 @@ SourceURIFinder::visit(const URIListedOnlyLabel &label)
                 _imp->eapi.supported()->ebuild_options()->restrict_mirror_override()->end(),
                 std::bind(&uri_start_with_override, std::placeholders::_1, _imp->url))) {
         visit(URIMirrorsThenListedLabel(label.text()));
+        return;
     }
-    else {
-        add_local_mirrors();
-        add_listed();
-    }
+
+    uri_remove_prefixes();
+
+    add_local_mirrors();
+    add_listed();
 }
 
 void
@@ -156,20 +188,29 @@ SourceURIFinder::visit(const URIManualOnlyLabel &label)
             std::find_if(_imp->eapi.supported()->ebuild_options()->restrict_mirror_override()->begin(),
                 _imp->eapi.supported()->ebuild_options()->restrict_mirror_override()->end(),
                 std::bind(&uri_start_with_override, std::placeholders::_1, _imp->url))) {
+        /* Divert to the other, less restrictive label. */
         visit(URIMirrorsThenListedLabel(label.text()));
+        return;
     }
     else if (_imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->end() !=
-            std::find_if(_imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->begin(),
-                _imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->end(),
-                std::bind(&uri_start_with_override, std::placeholders::_1, _imp->url))) {
+                std::find_if(_imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->begin(),
+                    _imp->eapi.supported()->ebuild_options()->restrict_fetch_override()->end(),
+                    std::bind(&uri_start_with_override, std::placeholders::_1, _imp->url))) {
+        /* Divert to the other, less restrictive label. */
         visit(URIListedOnlyLabel(label.text()));
+        return;
     }
+
+    uri_remove_prefixes();
 }
 
 void
 SourceURIFinder::visit(const URILocalMirrorsOnlyLabel &)
 {
     Context context("When using URILocalMirrorsOnlyLabel:");
+
+    uri_remove_prefixes();
+
     add_local_mirrors();
 }
 

--- a/paludis/repositories/e/source_uri_finder.hh
+++ b/paludis/repositories/e/source_uri_finder.hh
@@ -44,14 +44,17 @@ namespace paludis
                 void add_mirrors();
                 void add_listed();
 
+                void uri_remove_prefix(const std::string & overridestr);
+                void uri_remove_prefixes();
+
             public:
                 SourceURIFinder(const Environment * const env,
                         const Repository * const repo,
                         const EAPI & eapi,
-                        const std::string & url,
                         const std::string & filename,
                         const std::string & mirrors_name,
-                        const GetMirrorsFunction & fn);
+                        const GetMirrorsFunction & fn,
+                        const std::string & url);
 
                 ~SourceURIFinder();
 

--- a/paludis/repositories/e/source_uri_finder_TEST.cc
+++ b/paludis/repositories/e/source_uri_finder_TEST.cc
@@ -57,8 +57,8 @@ TEST(SourceURIFinder, Works)
     env.add_repository(1, repo);
     const std::shared_ptr<const EAPI> eapi(EAPIData::get_instance()->eapi_from_string("paludis-1"));
 
-    SourceURIFinder f(&env, repo.get(), *eapi, "http://example.com/path/input", "output", "monkey",
-            get_mirrors_fn);
+    SourceURIFinder f(&env, repo.get(), *eapi, "output", "monkey",
+            get_mirrors_fn, "http://example.com/path/input");
     URIMirrorsThenListedLabel label("mirrors-then-listed");
     label.accept(f);
 
@@ -83,7 +83,7 @@ TEST(SourceURIFinder, Mirrors)
     env.add_repository(1, repo);
     const std::shared_ptr<const EAPI> eapi(EAPIData::get_instance()->eapi_from_string("paludis-1"));
 
-    SourceURIFinder f(&env, repo.get(), *eapi, "mirror://example/path/input", "output", "repo", get_mirrors_fn);
+    SourceURIFinder f(&env, repo.get(), *eapi, "output", "repo", get_mirrors_fn, "mirror://example/path/input");
     URIMirrorsThenListedLabel label("mirrors-then-listed");
     label.accept(f);
 


### PR DESCRIPTION
We switched through labels correctly, but never removed the prefix we detected.

Do that, so that fetching actually works.

This is a fixup for #74.

Merging without a merge commit.