### PR TITLE
EAPI=8: PROPERTIES=test_network fixups.

### DIFF
--- a/paludis/repositories/e/ebuild/ebuild.bash
+++ b/paludis/repositories/e/ebuild/ebuild.bash
@@ -624,23 +624,6 @@ paludis_phase_to_function_name() {
     die "Usage error: Unknown phase '${1}'"
 }
 
-check_word_in_string() {
-    local word="${1}"
-    local string="${2}"
-    local ret='1'
-
-    [[ -z "${word}" ]] && die 'Usage error: illogical to search for empty word in a string'
-
-    if [[ -n "${string}" ]]; then
-        case "${string}" in
-            ("${word} "*|*" ${word}"|*" ${word} "*|"${word}")
-                ret='0'
-        esac
-    fi
-
-    return "${ret}"
-}
-
 ebuild_main()
 {
     if ! [[ -e /proc/self ]] && [[ "$(uname -s)" == Linux ]] ; then
@@ -710,7 +693,7 @@ ebuild_main()
 
         # Restrict network access if running under sandbox
         if [[ $action != unpack ]] && [[ $action != fetch_extra ]] ; then
-            if [[ 'test' != "${action}" ]] || ! check_word_in_string 'test_network' "${PROPERTIES}"; then
+            if [[ 'test' != "${action}" ]] || ! has 'test_network' "${PROPERTIES}"; then
                 if esandbox check 2>/dev/null; then
                     esandbox enable_net || ebuild_notice "warning" "esandbox enable_net returned failure"
                 fi
@@ -721,7 +704,7 @@ ebuild_main()
         local paludis_ebuild_phase_status="${?}"
 
         if [[ $action != unpack ]] && [[ $action != fetch_extra ]] ; then
-            if [[ 'test' != "${action}" ]] || ! check_word_in_string 'test_network' "${PROPERTIES}"; then
+            if [[ 'test' != "${action}" ]] || ! has 'test_network' "${PROPERTIES}"; then
                 if esandbox check 2>/dev/null; then
                     esandbox disable_net || ebuild_notice "warning" "esandbox disable_net returned failure"
                 fi

--- a/paludis/repositories/e/ebuild_id.cc
+++ b/paludis/repositories/e/ebuild_id.cc
@@ -50,6 +50,7 @@
 #include <paludis/notifier_callback.hh>
 #include <paludis/always_enabled_dependency_label.hh>
 #include <paludis/slot.hh>
+#include <paludis/dep_spec_flattener.hh>
 
 #include <paludis/util/fs_error.hh>
 #include <paludis/util/stringify.hh>
@@ -74,6 +75,8 @@
 #include <iterator>
 #include <algorithm>
 #include <ctime>
+#include <functional>
+#include <utility>
 
 using namespace paludis;
 using namespace paludis::erepository;
@@ -1655,6 +1658,8 @@ EbuildID::add_build_options(const std::shared_ptr<Choices> & choices) const
          * However, some elements, like strip, might be restricted, but
          * can be overridden by other things, like the new controllable
          * strip feature.
+         * Likewise, PROPERTIES="test_network" can override a test
+         * restriction.
          * For such cases, apply overrides.
          */
         if (restrict_key())
@@ -1664,7 +1669,25 @@ EbuildID::add_build_options(const std::shared_ptr<Choices> & choices) const
 
             bool strip_override = eapi()->supported()->tools_options()->controllable_strip();
 
-            mask_tests = f.s.end() != f.s.find("test");
+            /*
+             * Check for test override.
+             *
+             * Don't use the UnconditionalRestrictFinder here, since it's
+             * possible that the override is actually conditional.
+             */
+            const std::shared_ptr<const PackageID> package_id(shared_from_this());
+            DepSpecFlattener<PlainTextSpecTree, PlainTextDepSpec> properties(_imp->environment, package_id);
+            if (properties_key())
+                properties_key()->parse_value()->top()->accept(properties);
+            bool test_override = indirect_iterator(properties.end())
+                                    != std::find_if(indirect_iterator(properties.begin()),
+                                        indirect_iterator(properties.end()),
+                                            std::bind(std::equal_to<>(),
+                                                std::bind(std::mem_fn(&StringDepSpec::text),
+                                                    std::placeholders::_1),
+                                                "test_network"));
+            mask_tests = (f.s.end() != f.s.find("test"))
+                         && (!test_override);
             may_be_unrestricted_strip = (f.s.end() == f.s.find("strip")) || strip_override;
         }
 


### PR DESCRIPTION
#78 added support for `PROPERTIES=test_network`, but did not actually remove the mask if `RESTRICT=test` has been provided.

This fixes this up... and refactors the code to use `has` instead of the duplicated `check_word_in_string` shell function (oops...)